### PR TITLE
Add OIDC client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ A sigstore java client for interacting with sigstore infrastructure
 
 Minimum Java 8
 
-This is a WIP, currently only consists
-- fulcio client
+This is a WIP, currently consists of
+
+### fulcio client
 
 ```java
 // pre-requisites
@@ -29,14 +30,27 @@ byte[] signed = signature.sign();
 CertificateRequest cReq = new CertificateRequest(keys.getPublic(), signed);
 
 // ask fulcio for a signing cert chain for our public key
-SigningCertificate signingCert = fulcioClient.SigningCert(cReq, token);
+SigningCertificate signingCert = fulcioClient.SigningCert(cReq, idToken);
 
 // sign something with our private key, throw it away and save the cert with the artifact
 ```
 
+### oidc client
+
+```
+OidcClient oidcClient = OidcClient.builder().build();
+
+EmailIdToken eid = oidcClient.getIDToken(null);
+
+// email address, to sign and use when creating a CertificateRequest for fulcio
+eid.getEmailAddress();
+// idToken, to use when making a call to FulcioClient#SigningCert
+eid.getIdToken();
+
+```
+
 To be added
 - rekor client
-- dex/oidc client
 
 Maybe to be added here or somewhere else
 - signer

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,17 +20,24 @@ tasks.compileTestJava {
 dependencies {
     implementation(platform("com.google.cloud:libraries-bom:24.3.0"))
     implementation("com.google.http-client:google-http-client-apache-v2")
-    implementation("com.google.api-client:google-api-client-gson:1.31.5")
+    implementation("com.google.http-client:google-http-client-gson")
 
     implementation("com.google.code.gson:gson:2.8.9")
     implementation("org.conscrypt:conscrypt-openjdk-uber:2.5.2") {
         because("contains library code for all platforms")
     }
 
+    implementation(platform("com.google.oauth-client:google-oauth-client-bom:1.33.3"))
+    implementation("com.google.oauth-client:google-oauth-client")
+    implementation("com.google.oauth-client:google-oauth-client-jetty")
+    implementation("com.google.oauth-client:google-oauth-client-java6")
+
     testImplementation("junit:junit:4.12")
     testImplementation("com.nimbusds:oauth2-oidc-sdk:6.21.2")
     testImplementation("com.nimbusds:nimbus-jose-jwt:9.18")
+    testImplementation("no.nav.security:mock-oauth2-server:0.4.4")
     testImplementation("org.bouncycastle:bcutil-jdk15on:1.70")
+    testImplementation("net.sourceforge.htmlunit:htmlunit:2.61.0")
 }
 
 spotless {

--- a/src/main/java/dev/sigstore/http/HttpProvider.java
+++ b/src/main/java/dev/sigstore/http/HttpProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.http;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
+import java.util.concurrent.TimeUnit;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+public class HttpProvider {
+  public static final String DEFAULT_USER_AGENT = "sigstoreJavaClient/0.0.1";
+  public static final int DEFAULT_TIMEOUT = 60;
+  public static final boolean DEFAULT_USE_SSL = true;
+
+  private final HttpTransport httpTransport;
+
+  public static HttpProvider.Builder builder() {
+    return new Builder();
+  }
+
+  private HttpProvider(HttpTransport httpTransport) {
+    this.httpTransport = httpTransport;
+  }
+
+  public HttpTransport getHttpTransport() {
+    return httpTransport;
+  }
+
+  public static class Builder {
+    private long timeout = DEFAULT_TIMEOUT;
+    private String userAgent = DEFAULT_USER_AGENT;
+    private boolean useSSLVerification = DEFAULT_USE_SSL;
+
+    private Builder() {}
+
+    /** A non negative timeout for each requests, defaults to {@value DEFAULT_TIMEOUT}. */
+    public HttpProvider.Builder setTimeout(long timeout) {
+      if (timeout < 0) {
+        throw new IllegalArgumentException("Invalid timeout: " + timeout);
+      }
+      this.timeout = timeout;
+      return this;
+    }
+
+    /** User agent string to include in requests, defaults to {@value DEFAULT_USER_AGENT}. */
+    public HttpProvider.Builder setUserAgent(String userAgent) {
+      if (userAgent == null || userAgent.trim().isEmpty()) {
+        throw new IllegalArgumentException("Invalid useragent: " + userAgent);
+      }
+      this.userAgent = userAgent;
+      return this;
+    }
+
+    /**
+     * Configure SSL verification, there's probably not many good reason to turn this off, defaults
+     * to {@value DEFAULT_USE_SSL}
+     */
+    public HttpProvider.Builder setUseSSLVerification(boolean enable) {
+      this.useSSLVerification = enable;
+      return this;
+    }
+
+    public HttpProvider build() {
+      HttpClientBuilder hcb = ApacheHttpTransport.newDefaultHttpClientBuilder();
+      hcb.setConnectionTimeToLive(timeout, TimeUnit.SECONDS);
+      if (!useSSLVerification) {
+        hcb = hcb.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+      }
+      hcb.setUserAgent(userAgent);
+      HttpTransport httpTransport = new ApacheHttpTransport(hcb.build());
+      return new HttpProvider(httpTransport);
+    }
+  }
+}

--- a/src/main/java/dev/sigstore/oidc/client/OidcClient.java
+++ b/src/main/java/dev/sigstore/oidc/client/OidcClient.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.auth.oauth2.BearerToken;
+import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
+import com.google.api.client.auth.openidconnect.IdToken;
+import com.google.api.client.auth.openidconnect.IdTokenVerifier;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.Key;
+import com.google.api.client.util.store.DataStoreFactory;
+import com.google.api.client.util.store.MemoryDataStoreFactory;
+import dev.sigstore.http.HttpProvider;
+import java.io.IOException;
+import java.util.Arrays;
+import javax.annotation.Nullable;
+
+/** A client to obtain oidc tokens for use with sigstore. */
+public class OidcClient {
+
+  private static final String ID_TOKEN_KEY = "id_token";
+  private static final String DEFAULT_CLIENT_ID = "sigstore";
+  private static final String DEFAULT_ISSUER = "https://oauth2.sigstore.dev/auth";
+  private static final String WELL_KNOWN_CONFIG = "/.well-known/openid-configuration";
+
+  private final HttpProvider httpProvider;
+  private final String clientId;
+  private final String issuer;
+  private final BrowserHandler browserHandler;
+
+  private OidcClient(
+      HttpProvider httpProvider, String issuer, String clientId, BrowserHandler browserHandler) {
+    this.httpProvider = httpProvider;
+    this.clientId = clientId;
+    this.issuer = issuer;
+    this.browserHandler = browserHandler;
+  }
+
+  public static OidcClient.Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private HttpProvider httpProvider;
+    private String clientId = DEFAULT_CLIENT_ID;
+    private String issuer = DEFAULT_ISSUER;
+    private BrowserHandler browserHandler = null;
+
+    private Builder() {}
+
+    /** Configure the http properties, see {@link HttpProvider} */
+    public Builder setHttpProvider(HttpProvider httpProvider) {
+      this.httpProvider = httpProvider;
+      return this;
+    }
+
+    /** The client id used in the oidc request, defaults to {@value DEFAULT_CLIENT_ID}. */
+    public Builder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    /** The issuer of the oidc tokens (the oidc service) {@value DEFAULT_ISSUER}. */
+    public Builder setIssuer(String issuer) {
+      this.issuer = issuer;
+      return this;
+    }
+
+    /**
+     * Alternative to default browser behavior, only use if you truly need to open with some sort of
+     * custom browser, like in test or headless environments.
+     */
+    public Builder setBrowser(BrowserHandler browserHandler) {
+      this.browserHandler = browserHandler;
+      return this;
+    }
+
+    public OidcClient build() {
+      HttpProvider hp = httpProvider != null ? httpProvider : HttpProvider.builder().build();
+      BrowserHandler bh =
+          browserHandler != null
+              ? browserHandler
+              : new AuthorizationCodeInstalledApp.DefaultBrowser()::browse;
+      return new OidcClient(hp, issuer, clientId, bh);
+    }
+  }
+
+  /**
+   * Get an id token from the oidc provider with openid and email scopes
+   *
+   * @param expectedEmailAddress optional parameter to verify the subject email address does indeed
+   *     match the value in the id token
+   * @return an openid token with additional email scopes
+   * @throws OidcException if an error occurs doing the authorization flow
+   */
+  public EmailIdToken getIDToken(@Nullable String expectedEmailAddress) throws OidcException {
+    JsonFactory jsonFactory = new GsonFactory();
+    HttpTransport httpTransport = httpProvider.getHttpTransport();
+    DataStoreFactory memStoreFactory = new MemoryDataStoreFactory();
+    OIDCEndpoints endpoints;
+    try {
+      endpoints = parseDiscoveryDocument(jsonFactory, httpTransport);
+    } catch (IOException e) {
+      // TODO: maybe a more descriptive exception message
+      throw new OidcException(
+          "ioexception obtaining and parsing oidc configuration for " + issuer, e);
+    }
+    AuthorizationCodeFlow.Builder flowBuilder =
+        new AuthorizationCodeFlow.Builder(
+                BearerToken.authorizationHeaderAccessMethod(),
+                httpTransport,
+                jsonFactory,
+                new GenericUrl(endpoints.getTokenEndpoint()),
+                new ClientParametersAuthentication(clientId, null),
+                clientId,
+                endpoints.getAuthEndpoint())
+            .enablePKCE()
+            .setScopes(Arrays.asList("openid", "email"))
+            .setCredentialCreatedListener(
+                (credential, tokenResponse) ->
+                    memStoreFactory
+                        .getDataStore("user")
+                        .set(ID_TOKEN_KEY, tokenResponse.get(ID_TOKEN_KEY).toString()));
+    AuthorizationCodeInstalledApp app =
+        new AuthorizationCodeInstalledApp(
+            flowBuilder.build(), new LocalServerReceiver(), browserHandler::openBrowser);
+
+    String idTokenString = null;
+    IdToken parsedIdToken = null;
+    try {
+      app.authorize("user");
+      idTokenString = (String) memStoreFactory.getDataStore("user").get(ID_TOKEN_KEY);
+      parsedIdToken = IdToken.parse(jsonFactory, idTokenString);
+      IdTokenVerifier idTokenVerifier =
+          new IdTokenVerifier.Builder()
+              .setIssuer(issuer)
+              .setCertificatesLocation(endpoints.getJwksUri())
+              .build();
+      if (!idTokenVerifier.verify(parsedIdToken)) {
+        throw new OidcException("id token could not be verified");
+      }
+    } catch (IOException e) {
+      // TODO: maybe a more descriptive exception message
+      throw new OidcException("ioexception during oidc handshake", e);
+    }
+
+    String emailFromIDToken = (String) parsedIdToken.getPayload().get("email");
+    boolean emailVerified = (boolean) parsedIdToken.getPayload().get("email_verified");
+    if (expectedEmailAddress != null && !emailFromIDToken.equals(expectedEmailAddress)) {
+      throw new OidcException(
+          String.format(
+              "email in ID token '%s' does not match address specified to plugin '%s'",
+              emailFromIDToken, expectedEmailAddress));
+    } else if (Boolean.FALSE.equals(emailVerified)) {
+      throw new OidcException(
+          String.format(
+              "identity provider '%s' reports email address '%s' has not been verified",
+              parsedIdToken.getPayload().getIssuer(), expectedEmailAddress));
+    }
+
+    return new EmailIdToken(emailFromIDToken, idTokenString);
+  }
+
+  // Parses a oidc discovery document to discover other endpoints. This method does not
+  // parse all the values, only the endpoints we care about.
+  OIDCEndpoints parseDiscoveryDocument(JsonFactory jsonFactory, HttpTransport httpTransport)
+      throws IOException {
+    HttpRequestFactory requestFactory =
+        httpTransport.createRequestFactory(
+            request -> {
+              request.setParser(jsonFactory.createJsonObjectParser());
+            });
+    GenericUrl wellKnownConfig = new GenericUrl(issuer);
+    wellKnownConfig.appendRawPath(WELL_KNOWN_CONFIG);
+    HttpRequest request = requestFactory.buildGetRequest(wellKnownConfig);
+    return request.execute().parseAs(OIDCEndpoints.class);
+  }
+
+  /** Internal. */
+  public static class OIDCEndpoints extends GenericJson {
+    @Key("authorization_endpoint")
+    private String authEndpoint;
+
+    @Key("token_endpoint")
+    private String tokenEndpoint;
+
+    @Key("jwks_uri")
+    private String jwksUri;
+
+    public String getAuthEndpoint() {
+      return authEndpoint;
+    }
+
+    public String getTokenEndpoint() {
+      return tokenEndpoint;
+    }
+
+    public String getJwksUri() {
+      return jwksUri;
+    }
+  }
+
+  /** A token from a provider with both openid and email scope claims. */
+  public static class EmailIdToken {
+    private final String emailAddress;
+    private final String idToken;
+
+    private EmailIdToken(String emailAddress, String idToken) {
+      this.emailAddress = emailAddress;
+      this.idToken = idToken;
+    }
+
+    /** The email address claim from the token. */
+    public String getEmailAddress() {
+      return emailAddress;
+    }
+
+    /** The full oauth token obtained from the provider. */
+    public String getIdToken() {
+      return idToken;
+    }
+  }
+
+  /** Interface for allowing custom browser handlers for OauthClients. */
+  @FunctionalInterface
+  public interface BrowserHandler {
+    /** Opens a browser to allow a user to complete the oauth browser workflow. */
+    void openBrowser(String url) throws IOException;
+  }
+}

--- a/src/main/java/dev/sigstore/oidc/client/OidcException.java
+++ b/src/main/java/dev/sigstore/oidc/client/OidcException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+public class OidcException extends Exception {
+  public OidcException(String message) {
+    super(message);
+  }
+
+  public OidcException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/dev/sigstore/oidc/client/OidcClientTest.java
+++ b/src/test/java/dev/sigstore/oidc/client/OidcClientTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import no.nav.security.mock.oauth2.OAuth2Config;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OidcClientTest {
+
+  private MockOAuth2Server server;
+
+  @Before
+  public void setUpServer() throws IOException {
+    // TODO: Remove custom config key once (https://github.com/navikt/mock-oauth2-server/issues/247)
+    // is updated
+    String json =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/oidc/server/config.json"), Charsets.UTF_8);
+    var cfg = OAuth2Config.Companion.fromJson(json);
+    server = new MockOAuth2Server(cfg);
+    server.start();
+  }
+
+  @After
+  public void shutdownServer() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  public void testAuthFlow() throws IOException, OidcException {
+    var issuerId = "test-default";
+
+    try (var webClient = new WebClient()) {
+      var oidcClient =
+          OidcClient.builder()
+              .setIssuer(server.issuerUrl(issuerId).toString())
+              .setBrowser(webClient::getPage)
+              .build();
+
+      var eid = oidcClient.getIDToken(null);
+      Assert.assertEquals("test.person@test.com", eid.getEmailAddress());
+    }
+  }
+}

--- a/src/test/java/dev/sigstore/testing/FakeOIDCServer.java
+++ b/src/test/java/dev/sigstore/testing/FakeOIDCServer.java
@@ -36,6 +36,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
 
+// TODO: this can probably be replaces with a MockOauth2Server like in OidcClietTest
 public class FakeOIDCServer implements AutoCloseable {
 
   public static final String USER = "test@example.com";

--- a/src/test/resources/dev/sigstore/oidc/server/config.json
+++ b/src/test/resources/dev/sigstore/oidc/server/config.json
@@ -1,0 +1,24 @@
+{
+  "tokenProvider" : {
+    "keyProvider" : {
+      "initialKeys" : "{\"alg\": \"ES256\",\"kty\": \"EC\",\"d\": \"o9INzHyU_I97djF36YQRpHCJxFTgDTbS1OtwUnHc34U\",\"use\":\"sig\",\"crv\": \"P-256\",\"kid\": \"test-default\",\"x\": \"umybCYzE-VX_UAIJaX3wc-GTOgB7WDp7A3JJAKW_hqU\",\"y\": \"m_sCzuMjiBSQ7At9yNktMQvE1cCKq68jO7wnRczwKw8\"}",
+      "algorithm" : "ES256"
+    }
+  },
+  "tokenCallbacks" : [
+    {
+      "issuerId": "test-default",
+      "tokenExpiry": 120,
+      "requestMappings": [
+        {
+          "requestParam": "scope",
+          "match": "openid email",
+          "claims": {
+            "audience": "sigstore",
+            "email": "test.person@test.com",
+            "email_verified": true
+          }
+        }
+      ]
+    }]
+}


### PR DESCRIPTION
This is a convenience wrapper around the google oauth client, with
specific defaults for sigstore AND automatic endpoint detection
from the well known issuer open id configuration url (which
strangely is not part of the oauth client).

Signed-off-by: Appu Goundan <appu@google.com>
