### PR TITLE
Use Java 11 in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
     - name: Setup Go environment
       uses: actions/setup-go@v3.0.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,11 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+tasks.compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_11.majorVersion
+    targetCompatibility = JavaVersion.VERSION_11.majorVersion
+}
+
 dependencies {
     implementation(platform("com.google.cloud:libraries-bom:24.3.0"))
     implementation("com.google.http-client:google-http-client-apache-v2")


### PR DESCRIPTION
Also fixes fake CT log with response that is compatible
with what fulcio is expecting (otherwise test fails).

Signed-off-by: Appu Goundan <appu@google.com>