### PR TITLE
fix tests on os x

### DIFF
--- a/src/test/java/dev/sigstore/testing/FulcioWrapper.java
+++ b/src/test/java/dev/sigstore/testing/FulcioWrapper.java
@@ -15,12 +15,11 @@
  */
 package dev.sigstore.testing;
 
-import org.junit.jupiter.api.extension.*;
-
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.jupiter.api.extension.*;
 
 /**
  * A test fixture to start fulcio from an executable on the system path. This requires fulcio to be

--- a/src/test/java/dev/sigstore/testing/FulcioWrapper.java
+++ b/src/test/java/dev/sigstore/testing/FulcioWrapper.java
@@ -15,11 +15,12 @@
  */
 package dev.sigstore.testing;
 
+import org.junit.jupiter.api.extension.*;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.junit.jupiter.api.extension.*;
 
 /**
  * A test fixture to start fulcio from an executable on the system path. This requires fulcio to be
@@ -57,6 +58,8 @@ public class FulcioWrapper implements BeforeEachCallback, AfterEachCallback, Par
     System.out.println(Files.readString(fulcioLog));
     Files.deleteIfExists(fulcioLog);
     Files.deleteIfExists(fulcioConfig);
+    // For weirdness in OS X
+    Files.deleteIfExists(Path.of("@fulcio-legacy-grpc-socket"));
     Thread.sleep(1000); // give the server a chance to shutdown
   }
 


### PR DESCRIPTION
Running Fulcio from gradle leaves @fulcio-legacy-grpc-socket file in the project root that then blocks further tests from work due to port in use errors.

Signed-off-by: Patrick Flynn <patrick@chainguard.dev>
