### PR TITLE
Use GSON as a singleton since config is shared across the SDK.

### DIFF
--- a/src/main/java/dev/sigstore/fulcio/client/CertificateRequest.java
+++ b/src/main/java/dev/sigstore/fulcio/client/CertificateRequest.java
@@ -15,7 +15,8 @@
  */
 package dev.sigstore.fulcio.client;
 
-import dev.sigstore.json.GsonSupplier;
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import java.security.PublicKey;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,6 +65,6 @@ public abstract class CertificateRequest {
     data.put("publicKey", key);
     data.put("signedEmailAddress", getProofOfPossession());
 
-    return new GsonSupplier().get().toJson(data);
+    return GSON.get().toJson(data);
   }
 }

--- a/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
+++ b/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
@@ -20,14 +20,12 @@ import static dev.sigstore.json.GsonSupplier.GSON;
 import com.google.api.client.util.PemReader;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonParseException;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringReader;
 import dev.sigstore.fulcio.v2.CertificateChain;
 import dev.sigstore.fulcio.v2.SigningCertificateDetachedSCT;
 import dev.sigstore.fulcio.v2.SigningCertificateEmbeddedSCT;
-import dev.sigstore.json.GsonSupplier;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.*;
 import java.util.ArrayList;
@@ -120,16 +118,8 @@ public class SigningCertificate {
   }
 
   @VisibleForTesting
-  static SignedCertificateTimestamp decodeSCT(String sctHeader) throws SerializationException {
-    byte[] sct = Base64.getDecoder().decode(sctHeader);
-    return GSON.get()
-        .fromJson(
-            new InputStreamReader(new ByteArrayInputStream(sct), StandardCharsets.UTF_8),
-            SctJson.class)
-        .toSct();
   static SignedCertificateTimestamp decodeSCT(String sctJson) throws SerializationException {
-    Gson gson = new GsonSupplier().get();
-    return gson.fromJson(sctJson, SctJson.class).toSct();
+    return GSON.get().fromJson(sctJson, SctJson.class).toSct();
   }
 
   /** Returns true if the signing certificate constains an SCT embedded in the X509 extensions. */

--- a/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
+++ b/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
@@ -15,17 +15,19 @@
  */
 package dev.sigstore.fulcio.client;
 
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import com.google.api.client.util.PemReader;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
 import dev.sigstore.fulcio.v2.CertificateChain;
 import dev.sigstore.fulcio.v2.SigningCertificateDetachedSCT;
 import dev.sigstore.fulcio.v2.SigningCertificateEmbeddedSCT;
 import dev.sigstore.json.GsonSupplier;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.*;
 import java.util.ArrayList;
@@ -118,6 +120,13 @@ public class SigningCertificate {
   }
 
   @VisibleForTesting
+  static SignedCertificateTimestamp decodeSCT(String sctHeader) throws SerializationException {
+    byte[] sct = Base64.getDecoder().decode(sctHeader);
+    return GSON.get()
+        .fromJson(
+            new InputStreamReader(new ByteArrayInputStream(sct), StandardCharsets.UTF_8),
+            SctJson.class)
+        .toSct();
   static SignedCertificateTimestamp decodeSCT(String sctJson) throws SerializationException {
     Gson gson = new GsonSupplier().get();
     return gson.fromJson(sctJson, SctJson.class).toSct();

--- a/src/main/java/dev/sigstore/json/GsonSupplier.java
+++ b/src/main/java/dev/sigstore/json/GsonSupplier.java
@@ -27,14 +27,19 @@ import java.util.function.Supplier;
  * requests between sigstore and this client -- and should probably be used for any api call to
  * sigstore that expects JSON.
  */
-public class GsonSupplier implements Supplier<Gson> {
+public enum GsonSupplier implements Supplier<Gson> {
+  GSON;
+
+  private final Gson gson =
+      new GsonBuilder()
+          .registerTypeAdapter(byte[].class, new GsonByteArrayAdapter())
+          .registerTypeAdapterFactory(new GsonAdaptersRekorEntry())
+          .registerTypeAdapterFactory(new GsonAdaptersHashedRekordWrapper())
+          .disableHtmlEscaping()
+          .create();
+
   @Override
   public Gson get() {
-    return new GsonBuilder()
-        .registerTypeAdapter(byte[].class, new GsonByteArrayAdapter())
-        .registerTypeAdapterFactory(new GsonAdaptersRekorEntry())
-        .registerTypeAdapterFactory(new GsonAdaptersHashedRekordWrapper())
-        .disableHtmlEscaping()
-        .create();
+    return gson;
   }
 }

--- a/src/main/java/dev/sigstore/rekor/client/HashedRekordRequest.java
+++ b/src/main/java/dev/sigstore/rekor/client/HashedRekordRequest.java
@@ -15,7 +15,8 @@
  */
 package dev.sigstore.rekor.client;
 
-import dev.sigstore.json.GsonSupplier;
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import dev.sigstore.rekor.*;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -74,7 +75,7 @@ public class HashedRekordRequest {
     data.put("apiVersion", "0.0.1");
     data.put("spec", hashedrekord);
 
-    return new GsonSupplier().get().toJson(data);
+    return GSON.get().toJson(data);
   }
 
   public Hashedrekord getHashedrekord() {

--- a/src/main/java/dev/sigstore/rekor/client/RekorClient.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorClient.java
@@ -15,9 +15,10 @@
  */
 package dev.sigstore.rekor.client;
 
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import com.google.api.client.http.*;
 import dev.sigstore.http.HttpProvider;
-import dev.sigstore.json.GsonSupplier;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -142,8 +143,7 @@ public class RekorClient {
     data.put("hash", hash);
     data.put("publicKey", publicKeyParams);
 
-    GsonSupplier gsonSupplier = new GsonSupplier();
-    String contentString = gsonSupplier.get().toJson(data);
+    String contentString = GSON.get().toJson(data);
     System.out.println(contentString);
     HttpRequest req =
         httpProvider
@@ -155,6 +155,6 @@ public class RekorClient {
     req.getHeaders().set("Accept", "application/json");
     req.getHeaders().set("Content-Type", "application/json");
     var response = req.execute();
-    return Arrays.asList(gsonSupplier.get().fromJson(response.parseAsString(), String[].class));
+    return Arrays.asList(GSON.get().fromJson(response.parseAsString(), String[].class));
   }
 }

--- a/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
@@ -15,10 +15,10 @@
  */
 package dev.sigstore.rekor.client;
 
+import static dev.sigstore.json.GsonSupplier.GSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Base64.getDecoder;
 
-import dev.sigstore.json.GsonSupplier;
 import dev.sigstore.rekor.Hashedrekord;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
@@ -40,8 +40,7 @@ public interface RekorEntry {
 
   @Value.Derived
   default Hashedrekord getBodyAsHashedrekord() {
-    return new GsonSupplier()
-        .get()
+    return GSON.get()
         .fromJson(new String(getDecoder().decode(getBody()), UTF_8), HashedRekordWrapper.class)
         .getSpec();
   }

--- a/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
@@ -15,8 +15,9 @@
  */
 package dev.sigstore.rekor.client;
 
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import com.google.common.reflect.TypeToken;
-import dev.sigstore.json.GsonSupplier;
 import java.net.URI;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -53,7 +54,7 @@ public interface RekorResponse {
    */
   static RekorResponse newRekorResponse(URI entryLocation, String rawResponse) {
     var type = new TypeToken<Map<String, RekorEntry>>() {}.getType();
-    Map<String, RekorEntry> entryMap = new GsonSupplier().get().fromJson(rawResponse, type);
+    Map<String, RekorEntry> entryMap = GSON.get().fromJson(rawResponse, type);
     if (entryMap.size() != 1) {
       throw new IllegalArgumentException(
           "Expecting a single rekor entry in response but found: " + entryMap.size());

--- a/src/main/java/dev/sigstore/rekor/client/RekorVerifier.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorVerifier.java
@@ -15,8 +15,9 @@
  */
 package dev.sigstore.rekor.client;
 
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import dev.sigstore.encryption.Keys;
-import dev.sigstore.json.GsonSupplier;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
@@ -69,7 +70,7 @@ public class RekorVerifier {
     // to provide the user with some useful information
     // (https://github.com/sigstore/sigstore-java/issues/34)
 
-    var signableJson = new GsonSupplier().get().toJson(signableContent);
+    var signableJson = GSON.get().toJson(signableContent);
 
     // TODO: Verify more than just "ec" signed rekor entries
     // (https://github.com/sigstore/sigstore-java/issues/32)

--- a/src/test/java/dev/sigstore/json/GsonSupplierTest.java
+++ b/src/test/java/dev/sigstore/json/GsonSupplierTest.java
@@ -15,13 +15,15 @@
  */
 package dev.sigstore.json;
 
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class GsonSupplierTest {
-  private final Gson gson = new GsonSupplier().get();
+  private final Gson gson = GSON.get();
 
   @Test
   public void testWrite() {

--- a/src/test/java/dev/sigstore/testing/FakeCTLogServer.java
+++ b/src/test/java/dev/sigstore/testing/FakeCTLogServer.java
@@ -15,7 +15,8 @@
  */
 package dev.sigstore.testing;
 
-import dev.sigstore.json.GsonSupplier;
+import static dev.sigstore.json.GsonSupplier.GSON;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -27,7 +28,9 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.extension.*;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * A fake CT long instance to run per test. Will inject CTLOGURL into the test store so it can be
@@ -61,7 +64,7 @@ public class FakeCTLogServer implements BeforeEachCallback, AfterEachCallback {
             .decode(
                 "BAMARjBEAiBwHMgDtObhrT8wkWid01FXlqvXz1tsRei64siSuwZp7gIgdyRBYHatNaOezI/AW57lKkUffra4cKOGdO+oHKBJARI="));
     content.put("timestamp", System.currentTimeMillis());
-    String resp = new GsonSupplier().get().toJson(content);
+    String resp = GSON.get().toJson(content);
 
     return new MockResponse().setResponseCode(200).setBody(resp);
   }


### PR DESCRIPTION
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>

Closes #42 

Supplier interface isn't really carrying any weight right now but left it since perhaps there's a world we might use DI in the SDK?

