### PR TITLE
fix unorthodox use of optional

### DIFF
--- a/src/main/java/dev/sigstore/rekor/client/RekorClient.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorClient.java
@@ -111,7 +111,7 @@ public class RekorClient {
     try {
       response = req.execute();
     } catch (HttpResponseException e) {
-      if (e.getStatusCode() == 404) return Optional.ofNullable(null);
+      if (e.getStatusCode() == 404) return Optional.empty();
       throw e;
     }
     return Optional.of(


### PR DESCRIPTION
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>

Still learning this old but new to me Java stuff.  Switched to use Optional.empty() to return null.