### PR TITLE
ignore intellij http client tool files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build
+http
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar


### PR DESCRIPTION
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>

I'm finding this [tool](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) very useful, but the *.http files it creates are a pain to manage between branches. 