### PR TITLE
add inclusion proof to Verification.

### DIFF
--- a/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
@@ -21,7 +21,7 @@ import static java.util.Base64.getDecoder;
 import dev.sigstore.json.GsonSupplier;
 import dev.sigstore.rekor.Hashedrekord;
 import java.util.List;
-import javax.annotation.Nullable;
+import java.util.Optional;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 
@@ -36,8 +36,7 @@ public interface RekorEntry {
     /** Return the signed entry timestamp. */
     String getSignedEntryTimestamp();
 
-    @Nullable
-    InclusionProof getInclusionProof();
+    Optional<InclusionProof> getInclusionProof();
   }
 
   /**

--- a/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
@@ -20,6 +20,8 @@ import static java.util.Base64.getDecoder;
 
 import dev.sigstore.json.GsonSupplier;
 import dev.sigstore.rekor.Hashedrekord;
+import java.util.List;
+import javax.annotation.Nullable;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 
@@ -33,6 +35,36 @@ public interface RekorEntry {
   interface Verification {
     /** Return the signed entry timestamp. */
     String getSignedEntryTimestamp();
+
+    @Nullable
+    InclusionProof getInclusionProof();
+  }
+
+  /**
+   * Inclusion proof to allow verification that the entry is truly part of the Rekor merkle tree.
+   */
+  @Value.Immutable
+  interface InclusionProof {
+
+    /**
+     * A list of hashes required to compute the inclusion proof, sorted in order from leaf to root.
+     *
+     * @return list of SHA256 hash values expressed in hexadecimal format
+     */
+    List<String> getHashes();
+
+    /** The index of the entry in the transparency log. */
+    Long getLogIndex();
+
+    /**
+     * The hash value stored at the root of the merkle tree at the time the proof was generated.
+     *
+     * @return SHA256 hash value expressed in hexadecimal format
+     */
+    String rootHash();
+
+    /** The size of the merkle tree at the time the inclusion proof was generated. */
+    Long getTreeSize();
   }
 
   /** Returns the content of the log entry. */

--- a/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
+++ b/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
@@ -85,6 +85,7 @@ public class RekorClientTest {
       throws IOException, CertificateException, NoSuchAlgorithmException, SignatureException,
           URISyntaxException, InvalidKeyException, OperatorCreationException {
     var newRekordRequest = createdRekorRequest();
+    client.putEntry(newRekordRequest);
     assertEquals(
         1,
         client
@@ -145,11 +146,11 @@ public class RekorClientTest {
     var entry = client.getEntry(resp.getUuid());
     assertTrue(entry.isPresent());
     assertEquals(resp.getEntry().getLogID(), entry.get().getLogID());
-    assertNotNull(entry.get().getVerification().getInclusionProof());
-    assertNotNull(entry.get().getVerification().getInclusionProof().getTreeSize());
-    assertNotNull(entry.get().getVerification().getInclusionProof().rootHash());
-    assertNotNull(entry.get().getVerification().getInclusionProof().getLogIndex());
-    assertTrue(entry.get().getVerification().getInclusionProof().getHashes().size() > 0);
+    assertTrue(entry.get().getVerification().getInclusionProof().isPresent());
+    assertNotNull(entry.get().getVerification().getInclusionProof().get().getTreeSize());
+    assertNotNull(entry.get().getVerification().getInclusionProof().get().rootHash());
+    assertNotNull(entry.get().getVerification().getInclusionProof().get().getLogIndex());
+    assertTrue(entry.get().getVerification().getInclusionProof().get().getHashes().size() > 0);
   }
 
   @Test

--- a/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
+++ b/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
@@ -15,8 +15,7 @@
  */
 package dev.sigstore.rekor.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableList;
 import dev.sigstore.encryption.signers.Signers;
@@ -63,14 +62,15 @@ public class RekorClientTest {
         resp.getEntryLocation().toString(),
         CoreMatchers.startsWith("https://rekor.sigstage.dev/api/v1/log/entries/"));
 
-    Assertions.assertNotNull(resp.getUuid());
-    Assertions.assertNotNull(resp.getRaw());
+    assertNotNull(resp.getUuid());
+    assertNotNull(resp.getRaw());
     var entry = resp.getEntry();
-    Assertions.assertNotNull(entry.getBody());
+    assertNotNull(entry.getBody());
     Assertions.assertTrue(entry.getIntegratedTime() > 1);
-    Assertions.assertNotNull(entry.getLogID());
+    assertNotNull(entry.getLogID());
     Assertions.assertTrue(entry.getLogIndex() > 0);
-    Assertions.assertNotNull(entry.getVerification().getSignedEntryTimestamp());
+    assertNotNull(entry.getVerification().getSignedEntryTimestamp());
+    //    Assertions.assertNotNull(entry.getVerification().getInclusionProof());
   }
 
   // TODO(patrick@chainguard.dev): don't use data from prod, create the data as part of the test
@@ -85,7 +85,6 @@ public class RekorClientTest {
       throws IOException, CertificateException, NoSuchAlgorithmException, SignatureException,
           URISyntaxException, InvalidKeyException, OperatorCreationException {
     var newRekordRequest = createdRekorRequest();
-    var resp = client.putEntry(newRekordRequest);
     assertEquals(
         1,
         client
@@ -146,6 +145,11 @@ public class RekorClientTest {
     var entry = client.getEntry(resp.getUuid());
     assertTrue(entry.isPresent());
     assertEquals(resp.getEntry().getLogID(), entry.get().getLogID());
+    assertNotNull(entry.get().getVerification().getInclusionProof());
+    assertNotNull(entry.get().getVerification().getInclusionProof().getTreeSize());
+    assertNotNull(entry.get().getVerification().getInclusionProof().rootHash());
+    assertNotNull(entry.get().getVerification().getInclusionProof().getLogIndex());
+    assertTrue(entry.get().getVerification().getInclusionProof().getHashes().size() > 0);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>

Adds inclusion proof data to our RekorEntry. Made it @nullable since it seems like inclusion proof is missing from the response to a post of a new entry to /entries.
