### PR TITLE
Add digest to result and cleanup exceptions

### DIFF
--- a/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/src/main/java/dev/sigstore/KeylessSigner.java
@@ -35,7 +35,7 @@ import java.nio.file.Path;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
-import org.conscrypt.ct.SerializationException;
+import org.bouncycastle.util.encoders.Hex;
 
 /** A full sigstore keyless signing flow. */
 public class KeylessSigner {
@@ -156,7 +156,7 @@ public class KeylessSigner {
 
   public KeylessSigningResult sign(Path artifact)
       throws OidcException, NoSuchAlgorithmException, SignatureException, InvalidKeyException,
-          UnsupportedAlgorithmException, SerializationException, CertificateException, IOException,
+          UnsupportedAlgorithmException, CertificateException, IOException,
           FulcioVerificationException, RekorVerificationException {
     var tokenInfo = oidcClient.getIDToken();
     var signingCert =
@@ -184,6 +184,7 @@ public class KeylessSigner {
     rekorVerifier.verifyEntry(rekorResponse.getEntry());
 
     return ImmutableKeylessSigningResult.builder()
+        .digest(Hex.toHexString(artifactDigest))
         .certPath(signingCert.getCertPath())
         .signature(signature)
         .entry(rekorResponse.getEntry())

--- a/src/main/java/dev/sigstore/KeylessSigningResult.java
+++ b/src/main/java/dev/sigstore/KeylessSigningResult.java
@@ -21,6 +21,9 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public interface KeylessSigningResult {
+  /** The hex encoded sha256 hash digest of the artifact */
+  String getDigest();
+
   /** The full certificate chain provided by fulcio for the public key used to sign the artifact */
   CertPath getCertPath();
 

--- a/src/main/java/dev/sigstore/fulcio/client/FulcioClient.java
+++ b/src/main/java/dev/sigstore/fulcio/client/FulcioClient.java
@@ -88,10 +88,9 @@ public class FulcioClient {
    * @return a {@link SigningCertificate} from fulcio
    * @throws IOException if the http request fials
    * @throws CertificateException if returned certificates could not be decoded
-   * @throws SerializationException if return sct could not be parsed
    */
   public SigningCertificate SigningCert(CertificateRequest cr)
-      throws IOException, CertificateException, SerializationException {
+      throws IOException, CertificateException {
     URI fulcioEndpoint = serverUrl.resolve(SIGNING_CERT_PATH);
 
     HttpRequest req =
@@ -122,6 +121,8 @@ public class FulcioClient {
             "no signed certificate timestamps were found in response from Fulcio");
       }
       return signingCert;
+    } catch (SerializationException se) {
+      throw new CertificateException("SCT could not be parsed", se);
     }
   }
 }


### PR DESCRIPTION
- Adds easier access to digest so we can reference it without recalculating it
- Cleans up a few exceptions that are not stdlib that were leaking out
    - we still have a lot of work to streamline exceptions though