### PR TITLE
Add calculation of UUID for getEntry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
     implementation("com.google.http-client:google-http-client-apache-v2")
     implementation("com.google.http-client:google-http-client-gson")
 
+    implementation("io.github.erdtman:java-json-canonicalization:1.1")
+
     // grpc deps
     implementation(platform("io.grpc:grpc-bom:1.46.0"))
     implementation("io.grpc:grpc-protobuf")

--- a/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/src/main/java/dev/sigstore/KeylessSigner.java
@@ -18,6 +18,7 @@ package dev.sigstore;
 import com.google.api.client.util.Preconditions;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Resources;
+import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.encryption.signers.Signer;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.fulcio.client.*;
@@ -173,7 +174,7 @@ public class KeylessSigner {
     }
     var rekorRequest =
         HashedRekordRequest.newHashedRekordRequest(
-            artifactDigest, signingCert.getLeafCertificate(), signature);
+            artifactDigest, Certificates.toPemBytes(signingCert.getLeafCertificate()), signature);
     var rekorResponse = rekorClient.putEntry(rekorRequest);
     rekorVerifier.verifyEntry(rekorResponse.getEntry());
 

--- a/src/main/java/dev/sigstore/rekor/client/RekorClient.java
+++ b/src/main/java/dev/sigstore/rekor/client/RekorClient.java
@@ -23,10 +23,7 @@ import dev.sigstore.http.HttpParams;
 import dev.sigstore.http.ImmutableHttpParams;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 /** A client to communicate with a rekor service instance. */
 public class RekorClient {
@@ -99,6 +96,10 @@ public class RekorClient {
     URI rekorEntryUri = serverUrl.resolve(resp.getHeaders().getLocation());
     String entry = resp.parseAsString();
     return RekorResponse.newRekorResponse(rekorEntryUri, entry);
+  }
+
+  public Optional<RekorEntry> getEntry(HashedRekordRequest hashedRekordRequest) throws IOException {
+    return getEntry(hashedRekordRequest.computeUUID());
   }
 
   public Optional<RekorEntry> getEntry(String UUID) throws IOException {


### PR DESCRIPTION
- Calculate UUID by recontructing the entry
- Add option to getEntry by HashedRekorRequest(sig,cert,artifact) on RekorClient
  UUID is calculated client side (avoids a search on the rekor instance)

Signed-off-by: Appu Goundan <appu@google.com>