### PR TITLE
Updates to rekor verification

### DIFF
--- a/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/src/main/java/dev/sigstore/encryption/Keys.java
@@ -81,7 +81,7 @@ public class Keys {
     PemObject section = pemReader.readPemObject();
     if (pemReader.readPemObject() != null) {
       throw new InvalidKeySpecException(
-          "ctfe public key must be only a single PEM encoded public key");
+          "sigstore public keys must be only a single PEM encoded public key");
     }
     // special handling for PKCS1 (rsa) public key
     if (section.getType().equals("RSA PUBLIC KEY")) {


### PR DESCRIPTION
- Verify logId matches supplied public key for verification
- Clean up some error messages
- Use json canonicalizer instead of custom logic

Signed-off-by: Appu Goundan <appu@google.com>
