### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+
+# This workflow will build a Java project with Gradle and
+# cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Java CI with Gradle
@@ -12,6 +14,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call: # allow this workflow to be called by other workflows
 
 jobs:
   build:
@@ -36,7 +39,7 @@ jobs:
     - name: Install Fulcio
       run: |
           go install github.com/sigstore/fulcio@main
-          
+
     - name: Build with Gradle
       uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
       with:

--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -1,0 +1,108 @@
+name: Tag and Build Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: new release version
+        required: true
+        default: (for example, 0.1.0)
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check inputs
+        run: |
+          if [[ ! "${{ github.event.inputs.release_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo 'version "${{ github.event.inputs.release_version }}" not in ###.###.### format'
+            exit 1
+          fi
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
+  create-tag:
+    needs: [checks, ci]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/v${{ github.event.inputs.release_version }}",
+              sha: context.sha
+            })
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [create-tag]
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - name: checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/tags/v${{ github.event.inputs.release_version }}"
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'temurin'
+
+      - name: Build project
+        run: |
+          # override the version in gradle.properties
+          ./gradlew clean createReleaseBundle -Pversion=${{ github.event.inputs.release_version }}
+
+      - name: Hash Artifacts
+        id: hash
+        run: |
+          cd build/release
+          echo "::set-output name=hashes::$(sha256sum ./* | base64 -w0)"
+          sha256sum ./*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # tag=v3.1.0
+        with:
+          name: project-release-artifacts
+          path: ./build/release/
+          if-no-files-found: error
+
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [provenance, build]
+    permissions:
+      contents: write
+    steps:
+      - name: Download attestation
+        uses: actions/download-artifact@v3
+        with:
+          name: "${{ needs.provenance.outputs.attestation-name }}"
+          path: ./release/
+      - name: Download gradle release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: project-release-artifacts
+          path: ./release/
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.event.inputs.release_version }}
+          body: See [CHANGELOG.md](https://github.com/$GITHUB_REPOSITORY/CHANGELOG.md) for more details.
+          files: ./release/*
+          draft: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=dev.sigstore
-version=0.1-SNAPSHOT
+version=dev-SNAPSHOT


### PR DESCRIPTION
Manually triggered release action will tag and generate
java and slsa release artifacts.

Does not sign artifacts with sigstore/gpg yet.

Signed-off-by: Appu Goundan <appu@google.com>