### PR TITLE
javadoc/sources generation config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,10 +20,20 @@ repositories {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+    withJavadocJar()
+    withSourcesJar()
 }
 
-sourceSets["main"].java {
-    srcDirs("build/generated/sources/rekor-model/main")
+tasks.withType<Javadoc> {
+    (options as StandardJavadocDocletOptions).addBooleanOption("Xwerror", true)
+    (options as StandardJavadocDocletOptions).addStringOption("sourcepath", "src/main/java")
+    // intentionally ignore missing errors for now
+    (options as StandardJavadocDocletOptions).addBooleanOption("Xdoclint:all,-missing", true)
+}
+
+// TODO: keep until these code gen plugins explicitly declare dependencies
+tasks.named("sourcesJar") {
+    dependsOn(":generateProto", "::generateJsonSchema2DataClass0")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/dev/sigstore/encryption/certificates/transparency/package-info.java
+++ b/src/main/java/dev/sigstore/encryption/certificates/transparency/package-info.java
@@ -10,7 +10,7 @@
  * care about or use those.
  *
  * @see <a
- *     href="https://github.com/google/conscrypt/tree/86ff4e3fd4b6b3bb76a7ec0e91290384401ccbf3/common/src/main/java/org/conscrypt/ct>
+ *     href="https://github.com/google/conscrypt/tree/86ff4e3fd4b6b3bb76a7ec0e91290384401ccbf3/common/src/main/java/org/conscrypt/ct">
  *     certificate transparency directory at commit 86ff4e3fd4b6b3bb76a7ec0e91290384401ccbf3</a>
  */
 package dev.sigstore.encryption.certificates.transparency;

--- a/src/main/java/dev/sigstore/tuf/model/RootRole.java
+++ b/src/main/java/dev/sigstore/tuf/model/RootRole.java
@@ -21,9 +21,9 @@ import org.immutables.value.Value;
 /**
  * Represents the {@link Role} type as contained in the Root list of Roles.
  *
- * <p>This concrete class exists for GSON serialization reasons. GSON won't allow {@code
- * DelegationRole} and {@code Role} to both be JSON serializable since {@code DelegationRole}
- * extends {@Role}.
+ * <p>This concrete class exists for GSON serialization reasons. GSON won't allow {@link
+ * DelegationRole} and {@link Role} to both be JSON serializable since {@link DelegationRole}
+ * extends {@link Role}.
  */
 @Gson.TypeAdapters
 @Value.Immutable

--- a/src/main/java/dev/sigstore/tuf/model/TargetMeta.java
+++ b/src/main/java/dev/sigstore/tuf/model/TargetMeta.java
@@ -21,8 +21,8 @@ import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 
 /**
- * Metadata about a TUF target. {@see
- * https://theupdateframework.github.io/specification/latest/#targets}
+ * Metadata about a TUF target. @see <a
+ * href="https://theupdateframework.github.io/specification/latest/#targets">targets</a>
  */
 @Gson.TypeAdapters
 @Value.Immutable


### PR DESCRIPTION
Signed-off-by: Appu Goundan <appu@google.com>

This doesn't full enforce javadoc lint, checks for most of the correctness stuff. There is an exception for missing tags, because it is too big of a problem to fix right now.

the Temurin jdk seems to have a much more aggressive javadoc checker, which is why CI is failing, but not locally on my machine.