### PR TITLE
Fix permissions for CI in releases.

### DIFF
--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -18,6 +18,8 @@ jobs:
             exit 1
           fi
   ci:
+    permissions:
+      id-token: write # To run github oidc tests
     uses: ./.github/workflows/ci.yaml
 
   create-tag:


### PR DESCRIPTION
Need to define permissions allowed for the re-usable workflow.

Signed-off-by: Appu <appu@google.com>
