### PR TITLE
Add cancel-in-progress so PR builds do not wait stale jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,13 @@ on:
     branches: [ main ]
   workflow_call: # allow this workflow to be called by other workflows
 
+concurrency:
+  # On master/release, we don't want any jobs cancelled
+  # On PR branches, we cancel the job if new commits are pushed
+  # More info: https://stackoverflow.com/a/70972844/1261287
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
#### Summary

Cancel state PR builds when new changes are pushed.

#### Release Note

* Improve GitHub Actions feedback by cancelling stale jobs when new changes come to PRs

#### Documentation

NONE