### PR TITLE
Rename CI workflow: Java CI with Gradle -> Test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@
 # cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Test
 
 on:
   push:


### PR DESCRIPTION
#### Summary

`Java CI with Gradle` does not add much value, and `Test` is just enough.

#### Release Note

NONE

#### Documentation

NONE
