### PR TITLE
Remove com.fasterxml.jackson.core:jackson-databind from sigstore-java

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -49,7 +49,6 @@ dependencies {
     testImplementation("net.sourceforge.htmlunit:htmlunit:2.61.0")
 
     implementation("javax.validation:validation-api:2.0.1.Final")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
 }
 
 protobuf {


### PR DESCRIPTION
#### Summary

`sigstore-java` uses gson anyway, so `jackson` is not needed.

#### Release Note

* Remove unused jackson-databind dependency from sigstore-java

#### Documentation

NONE