### PR TITLE
Set ci to not fail-fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         java-version: [11, 17]
+      fail-fast: false
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Allows us to see the results of both java11 and java17 even if one fails.

Signed-off-by: Appu <appu@google.com>
