### PR TITLE
Add the expected checksum for gradle distribution

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Summary

It would make dev environments more secure by preventing MITM attacks
See https://gradle.org/release-checksums/#v7.5.1

#### Release Note

* Added verification of Gradle distribution when building sigstore-java

#### Documentation

NONE