### PR TITLE
Adds a Tuf local store abstraction and a file based implementation

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation("com.google.oauth-client:google-oauth-client-jetty")
     implementation("com.google.oauth-client:google-oauth-client-java6")
 
+    testImplementation(project(":sigstore-testkit"))
     testImplementation(platform("org.junit:junit-bom:5.9.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import static dev.sigstore.json.GsonSupplier.GSON;
+
+import com.google.common.annotations.VisibleForTesting;
+import dev.sigstore.tuf.model.Root;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/** Uses a local file system directory to store the trusted TUF metadata. */
+public class FileSystemTufStore implements TufLocalStore {
+
+  private static final String ROOT_FILE_NAME = "root.json";
+  private static final String SNAPSHOT_FILE_NAME = "snapshot.json";
+  private static final String TIMESTAMP_FILE_NAME = "timestamp.json";
+  private Path repoBaseDir;
+  private Root trustedRoot;
+
+  @VisibleForTesting
+  FileSystemTufStore(Path repoBaseDir, @Nullable Root trustedRoot) {
+    this.repoBaseDir = repoBaseDir;
+    this.trustedRoot = trustedRoot;
+  }
+
+  static TufLocalStore newFileSystemStore(Path repoBaseDir) throws IOException {
+    Path rootFile = repoBaseDir.resolve(ROOT_FILE_NAME);
+    Root trustedRoot = null;
+    if (rootFile.toFile().exists()) {
+      trustedRoot = GSON.get().fromJson(Files.readString(rootFile), Root.class);
+    }
+    return new FileSystemTufStore(repoBaseDir, trustedRoot);
+  }
+
+  @Override
+  public Optional<Root> getTrustedRoot() {
+    return Optional.ofNullable(trustedRoot);
+  }
+
+  @Override
+  public void setTrustedRoot(Root root) throws IOException {
+    if (root == null) {
+      throw new NullPointerException("Root should not be null");
+    }
+    Path rootPath = repoBaseDir.resolve(ROOT_FILE_NAME);
+    if (trustedRoot != null) {
+      // back it up
+      Files.move(
+          rootPath,
+          repoBaseDir.resolve(trustedRoot.getSignedMeta().getVersion() + "." + ROOT_FILE_NAME));
+    }
+    trustedRoot = root;
+    try (FileWriter fileWriter = new FileWriter(rootPath.toFile())) {
+      fileWriter.write(GSON.get().toJson(trustedRoot));
+    }
+  }
+
+  @Override
+  public void clearMetaDueToKeyRotation() throws IOException {
+    File snapshotMetaFile = repoBaseDir.resolve(SNAPSHOT_FILE_NAME).toFile();
+    if (snapshotMetaFile.exists()) {
+      Files.delete(snapshotMetaFile.toPath());
+    }
+    File timestampMetaFile = repoBaseDir.resolve(TIMESTAMP_FILE_NAME).toFile();
+    if (timestampMetaFile.exists()) {
+      Files.delete(timestampMetaFile.toPath());
+    }
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TufLocalStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TufLocalStore.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import dev.sigstore.tuf.model.Root;
+import java.io.IOException;
+import java.util.Optional;
+
+/** Defines the set of actions needed to support a local repository of TUF metadata. */
+public interface TufLocalStore {
+
+  /**
+   * If the local store has a root that has been blessed safe either by the client or through update
+   * and verification, then this method returns it.
+   */
+  Optional<Root> getTrustedRoot();
+
+  /**
+   * Once you have ascertained that your root is trustworthy use this method to persist it to your
+   * local store. This will usually only be called with a root loaded statically from a bundled
+   * trusted root, or after the successful verification of an updated root from a mirror.
+   *
+   * @see <a
+   *     href="https://theupdateframework.github.io/specification/latest/#detailed-client-workflow">5.3.8</a>
+   * @param root a root that has been proven trustworthy by the client
+   * @throws IOException since some implementations may persist the root to disk or over the network
+   *     we throw {@code IOException} in case of IO error.
+   */
+  void setTrustedRoot(Root root) throws IOException;
+
+  /**
+   * This clears out the snapshot and timestamp metadata from the store, as required when snapshot
+   * or timestamp verification keys have changed as a result of a root update.
+   *
+   * @see <a
+   *     href="https://theupdateframework.github.io/specification/latest/#detailed-client-workflow">5.3.11</a>
+   * @throws IOException implementations that read/write IO to clear the data may throw {@code
+   *     IOException}
+   */
+  void clearMetaDueToKeyRotation() throws IOException;
+}

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.sigstore.testkit.tuf.TestResources;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileSystemTufStoreTest {
+
+  @Test
+  void newFileSystemStore_empty(@TempDir Path repoBase) throws IOException {
+    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    assertFalse(tufLocalStore.getTrustedRoot().isPresent());
+  }
+
+  @Test
+  void newFileSystemStore_hasRepo(@TempDir Path repoBase) throws IOException {
+    String repoName = "remote-repo-prod";
+    TestResources.setupRepoFiles(repoName, repoBase, "root.json");
+    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    assertTrue(tufLocalStore.getTrustedRoot().isPresent());
+  }
+
+  @Test
+  void setTrustedRoot_noPrevious(@TempDir Path repoBase) throws IOException {
+    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    assertFalse(repoBase.resolve("root.json").toFile().exists());
+    tufLocalStore.setTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
+    assertEquals(1, repoBase.toFile().list().length);
+    assertTrue(repoBase.resolve("root.json").toFile().exists());
+  }
+
+  @Test
+  void setTrustedRoot_backupPerformed(@TempDir Path repoBase) throws IOException {
+    String repoName = "remote-repo-prod";
+    TestResources.setupRepoFiles(repoName, repoBase, "root.json");
+    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    int version = tufLocalStore.getTrustedRoot().get().getSignedMeta().getVersion();
+    assertFalse(repoBase.resolve(version + ".root.json").toFile().exists());
+    tufLocalStore.setTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
+    assertTrue(repoBase.resolve(version + ".root.json").toFile().exists());
+  }
+
+  @Test
+  void clearMetaDueToKeyRotation(@TempDir Path repoBase) throws IOException {
+    String repoName = "remote-repo-prod";
+    TestResources.setupRepoFiles(repoName, repoBase, "snapshot.json", "timestamp.json");
+    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    assertTrue(repoBase.resolve("snapshot.json").toFile().exists());
+    assertTrue(repoBase.resolve("timestamp.json").toFile().exists());
+    tufLocalStore.clearMetaDueToKeyRotation();
+    assertFalse(repoBase.resolve("snapshot.json").toFile().exists());
+    assertFalse(repoBase.resolve("timestamp.json").toFile().exists());
+  }
+}

--- a/sigstore-testkit/build.gradle.kts
+++ b/sigstore-testkit/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":sigstore-java"))
+    implementation("com.google.code.gson:gson:2.9.1")
+    implementation("com.google.guava:guava:31.1-jre")
+
     api(platform("org.junit:junit-bom:5.9.0"))
     api("org.junit.jupiter:junit-jupiter")
     api("org.assertj:assertj-core:3.23.1")

--- a/sigstore-testkit/src/main/java/dev/sigstore/testkit/tuf/TestResources.java
+++ b/sigstore-testkit/src/main/java/dev/sigstore/testkit/tuf/TestResources.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.testkit.tuf;
+
+import com.google.common.io.Resources;
+import dev.sigstore.json.GsonSupplier;
+import dev.sigstore.tuf.model.Root;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TestResources {
+
+  public static final Path CLIENT_TRUSTED_ROOT = Path.of(Resources.getResource("dev/sigstore/tuf/trusted-root.json").getPath());
+  public static final Path TUF_TEST_DATA_DIRECTORY = CLIENT_TRUSTED_ROOT.getParent();
+
+  public static void setupRepoFiles(String repoName, Path destinationDir, String... files)
+      throws IOException {
+    for (String file : files) {
+      Files.copy(
+          TestResources.TUF_TEST_DATA_DIRECTORY.resolve(repoName).resolve(file),
+          destinationDir.resolve(file));
+    }
+  }
+
+  public static Root loadRoot(Path rootPath) throws IOException {
+    return GsonSupplier.GSON.get().fromJson(Files.readString(rootPath), Root.class);
+  }
+}


### PR DESCRIPTION
TUF local repo store sets us up to be able to use an in-memory implementation for read-only file system scenarios.

Progress towards #60 

Signed-off-by: Patrick Flynn <patrick@chainguard.dev>
