### PR TITLE
Pass org.gradle.jvmargs arguments to test instances of Gradle as well to fix OutOfMemoryError: Metaspace in CI

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.testing.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.testing.gradle.kts
@@ -3,4 +3,7 @@ tasks.withType<Test>().configureEach {
         println("skipOidc: ${project.findProperty("skipOidc")}")
         systemProperty("sigstore-java.test.skipOidc", project.findProperty("skipOidc")!!)
     }
+    if (project.hasProperty("org.gradle.jvmargs")) {
+        systemProperty("sigstore-java.test.org.gradle.jvmargs", project.findProperty("org.gradle.jvmargs")!!)
+    }
 }

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
@@ -17,8 +17,8 @@
 package dev.sigstore.testkit
 
 import org.assertj.core.api.AbstractCharSequenceAssert
-import org.gradle.api.JavaVersion
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.DefaultGradleRunner
 import org.gradle.util.GradleVersion
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions
@@ -78,6 +78,19 @@ open class BaseGradleTest {
         gradleRunner
             .withGradleVersion(gradleVersion)
             .withProjectDir(projectDir.toFile())
+            .apply {
+                this as DefaultGradleRunner
+                // See https://github.com/gradle/gradle/issues/10527
+                // Gradle does not provide API to configure heap size for testkit-based Gradle executions,
+                // so we resort to org.gradle.testkit.runner.internal.DefaultGradleRunner
+                System.getProperty("sigstore-java.test.org.gradle.jvmargs")?.let { jvmArgs ->
+                    withJvmArguments(
+                        jvmArgs.split(Regex("\\s+"))
+                            .map { it.trim() }
+                            .filter { it.isNotBlank() }
+                    )
+                }
+            }
             .withArguments(*arguments)
             .forwardOutput()
 


### PR DESCRIPTION
#### Summary

See failure:  https://github.com/sigstore/sigstore-java/actions/runs/3063293316/jobs/4945208986#step:6:1893

Failure in my fork (without the fix):
* https://github.com/vlsi/sigstore-java/actions/runs/3063412642/jobs/4945462004#step:6:848

Workable CI in my fork (with the fix):
* https://github.com/vlsi/sigstore-java/actions/runs/3067445185

#### Release Note

NONE

#### Documentation

NONE