### PR TITLE
Run ci.yaml for all the branches, not just main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,11 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
   workflow_call: # allow this workflow to be called by other workflows
 
 concurrency:


### PR DESCRIPTION
#### Summary

This helps to test in forks as PR-based builds have no access to OIDC tokens

#### Release Note

NONE

#### Documentation

NONE