### PR TITLE
Delegate TUF resource fetching to MetaFetcher interface

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/HttpMetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/HttpMetaFetcher.java
@@ -41,6 +41,11 @@ public class HttpMetaFetcher implements MetaFetcher {
   }
 
   @Override
+  public String getSource() {
+    return mirror.toString();
+  }
+
+  @Override
   public Optional<Root> getRootAtVersion(int version)
       throws IOException, MetaFileExceedsMaxException {
     String versionFileName = version + ".root.json";

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/HttpMetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/HttpMetaFetcher.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import static dev.sigstore.json.GsonSupplier.GSON;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.json.gson.GsonFactory;
+import dev.sigstore.http.HttpClients;
+import dev.sigstore.http.ImmutableHttpParams;
+import dev.sigstore.tuf.model.Root;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public class HttpMetaFetcher implements MetaFetcher {
+
+  private static final int MAX_META_BYTES = 99 * 1024; // 99 KB
+  private URL mirror;
+
+  HttpMetaFetcher(URL mirror) {
+    this.mirror = mirror;
+  }
+
+  public static HttpMetaFetcher newFetcher(URL mirror) {
+    return new HttpMetaFetcher(mirror);
+  }
+
+  @Override
+  public Optional<Root> getRootAtVersion(int version)
+      throws IOException, MetaFileExceedsMaxException {
+    String versionFileName = version + ".root.json";
+    GenericUrl nextVersionUrl = new GenericUrl(mirror + "/" + versionFileName);
+    var req =
+        HttpClients.newHttpTransport(ImmutableHttpParams.builder().build())
+            .createRequestFactory(
+                request -> {
+                  request.setParser(GsonFactory.getDefaultInstance().createJsonObjectParser());
+                })
+            .buildGetRequest(nextVersionUrl);
+    req.getHeaders().setAccept("application/json; api-version=2.0");
+    req.getHeaders().setContentType("application/json");
+    req.setThrowExceptionOnExecuteError(false);
+    var resp = req.execute();
+    if (resp.getStatusCode() == 404) {
+      return Optional.empty();
+    }
+    if (resp.getStatusCode() != 200) {
+      throw new TufException(
+          String.format(
+              "Unexpected return from mirror. Status code: %s, status message: %s"
+                  + resp.getStatusCode()
+                  + resp.getStatusMessage()));
+    }
+    byte[] rootBytes = resp.getContent().readNBytes(MAX_META_BYTES);
+    if (rootBytes.length == MAX_META_BYTES && resp.getContent().read() != -1) {
+      throw new MetaFileExceedsMaxException(nextVersionUrl.toString(), MAX_META_BYTES);
+    }
+    return Optional.of(
+        GSON.get().fromJson(new String(rootBytes, StandardCharsets.UTF_8), Root.class));
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
@@ -23,6 +23,12 @@ import java.util.Optional;
 public interface MetaFetcher {
 
   /**
+   * Describes the source of the metadata being fetched from. e.g "http://mirror.bla/mirror",
+   * "mock", "c:/tmp".
+   */
+  String getSource();
+
+  /**
    * Fetch the {@link Root} at the specified {@code version}.
    *
    * @throws MetaFileExceedsMaxException when the retrieved file is larger than the maximum allowed

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import dev.sigstore.tuf.model.Root;
+import java.io.IOException;
+import java.util.Optional;
+
+/** Retrieves TUF metadata. */
+public interface MetaFetcher {
+
+  /**
+   * Fetch the {@link Root} at the specified {@code version}.
+   *
+   * @throws MetaFileExceedsMaxException when the retrieved file is larger than the maximum allowed
+   *     by the client
+   */
+  Optional<Root> getRootAtVersion(int version) throws IOException, MetaFileExceedsMaxException;
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TufClient.java
@@ -56,6 +56,7 @@ public class TufClient {
   private Verifiers.Supplier verifiers;
 
   private Function<URL, MetaFetcher> fetcherSupplier;
+  private ZonedDateTime updateStartTime;
 
   TufClient(Clock clock, Verifiers.Supplier verifiers, Function<URL, MetaFetcher> fetcherSupplier) {
     this.clock = clock;
@@ -63,7 +64,9 @@ public class TufClient {
     this.fetcherSupplier = fetcherSupplier;
   }
 
-  private ZonedDateTime updateStartTime;
+  public static Builder builder() {
+    return new Builder();
+  }
 
   // https://theupdateframework.github.io/specification/latest/#detailed-client-workflow
   public void updateRoot(Path trustedRootPath, URL mirror, TufLocalStore localStore)

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/TufClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/TufClientTest.java
@@ -210,7 +210,7 @@ class TufClientTest {
     Map<String, Key> publicKeys = ImmutableMap.of(PUB_KEY_1.getLeft(), PUB_KEY_1.getRight());
     Role delegate = ImmutableRootRole.builder().addKeyids(PUB_KEY_1.getLeft()).threshold(1).build();
     byte[] verificationMaterial = "alksdjfas".getBytes(StandardCharsets.UTF_8);
-    var client = new TufClient.Builder().setVerifiers(ALWAYS_FAILS).build();
+    var client = TufClient.builder().setVerifiers(ALWAYS_FAILS).build();
     try {
       client.verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
       fail("This should have failed since the public key for PUB_KEY_1 should fail to verify.");
@@ -305,7 +305,7 @@ class TufClientTest {
 
   @NotNull
   private static TufClient createTimeStaticTufClient() {
-    return new TufClient.Builder()
+    return TufClient.builder()
         .setClock(Clock.fixed(Instant.parse(TEST_STATIC_UPDATE_TIME), ZoneOffset.UTC))
         .setVerifiers(Verifiers::newVerifier)
         .setFetcherSupplier(HttpMetaFetcher::newFetcher)
@@ -314,7 +314,7 @@ class TufClientTest {
 
   @NotNull
   private static TufClient createAlwaysVerifyingTufClient() {
-    return new TufClient.Builder().setVerifiers(ALWAYS_VERIFIES).build();
+    return TufClient.builder().setVerifiers(ALWAYS_VERIFIES).build();
   }
 
   private static void setupMirror(String repoName, String... files) throws IOException {


### PR DESCRIPTION
This is to support easier re-use across resource types and facilitate testing. 

some drive-by refactoring to help readability. 
related to #60 
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>
