### PR TITLE
refactor tuf file system store

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TufClient.java
@@ -154,7 +154,7 @@ public class TufClient {
       // 5.3.7) set the trusted root metadata to the new root
       trustedRoot = newRoot;
       // 5.3.8) persist to repo
-      localStore.setTrustedRoot(trustedRoot);
+      localStore.storeTrustedRoot(trustedRoot);
       // 5.3.9) see if there are more versions go back 5.3.3
       nextVersion++;
     }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TufLocalStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TufLocalStore.java
@@ -26,7 +26,7 @@ public interface TufLocalStore {
    * If the local store has a root that has been blessed safe either by the client or through update
    * and verification, then this method returns it.
    */
-  Optional<Root> getTrustedRoot();
+  Optional<Root> loadTrustedRoot() throws IOException;
 
   /**
    * Once you have ascertained that your root is trustworthy use this method to persist it to your
@@ -39,7 +39,7 @@ public interface TufLocalStore {
    * @throws IOException since some implementations may persist the root to disk or over the network
    *     we throw {@code IOException} in case of IO error.
    */
-  void setTrustedRoot(Root root) throws IOException;
+  void storeTrustedRoot(Root root) throws IOException;
 
   /**
    * This clears out the snapshot and timestamp metadata from the store, as required when snapshot

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
@@ -28,7 +28,7 @@ class FileSystemTufStoreTest {
   @Test
   void newFileSystemStore_empty(@TempDir Path repoBase) throws IOException {
     TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    assertFalse(tufLocalStore.getTrustedRoot().isPresent());
+    assertFalse(tufLocalStore.loadTrustedRoot().isPresent());
   }
 
   @Test
@@ -36,14 +36,14 @@ class FileSystemTufStoreTest {
     String repoName = "remote-repo-prod";
     TestResources.setupRepoFiles(repoName, repoBase, "root.json");
     TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    assertTrue(tufLocalStore.getTrustedRoot().isPresent());
+    assertTrue(tufLocalStore.loadTrustedRoot().isPresent());
   }
 
   @Test
   void setTrustedRoot_noPrevious(@TempDir Path repoBase) throws IOException {
     TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertFalse(repoBase.resolve("root.json").toFile().exists());
-    tufLocalStore.setTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
+    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
     assertEquals(1, repoBase.toFile().list().length);
     assertTrue(repoBase.resolve("root.json").toFile().exists());
   }
@@ -53,9 +53,9 @@ class FileSystemTufStoreTest {
     String repoName = "remote-repo-prod";
     TestResources.setupRepoFiles(repoName, repoBase, "root.json");
     TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    int version = tufLocalStore.getTrustedRoot().get().getSignedMeta().getVersion();
+    int version = tufLocalStore.loadTrustedRoot().get().getSignedMeta().getVersion();
     assertFalse(repoBase.resolve(version + ".root.json").toFile().exists());
-    tufLocalStore.setTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
+    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
     assertTrue(repoBase.resolve(version + ".root.json").toFile().exists());
   }
 


### PR DESCRIPTION
My initial implementation had too much going on in the static factory, and creates uncertainty by having a constructor with a store path AND a trusted root.  I think it's better to initialize the store with the directory, and set the root afterwards. It also makes more sense to load these resources on demand as state can't get wonky and we'll pick up changes from other clients. 

Progress towards #60 
Signed-off-by: Patrick Flynn <patrick@chainguard.dev>