### PR TITLE
Adds a convenience method for verifying delegated roles

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
@@ -15,7 +15,10 @@
  */
 package dev.sigstore.tuf;
 
+import dev.sigstore.tuf.model.Role;
 import dev.sigstore.tuf.model.Root;
+import dev.sigstore.tuf.model.Timestamp;
+
 import java.io.IOException;
 import java.util.Optional;
 
@@ -35,4 +38,6 @@ public interface MetaFetcher {
    *     by the client
    */
   Optional<Root> getRootAtVersion(int version) throws IOException, MetaFileExceedsMaxException;
+
+  <T> Optional<T> getMeta(Role.Name name, Class<T> roleType) throws IOException, MetaFileExceedsMaxException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
@@ -1,0 +1,10 @@
+package dev.sigstore.tuf.model;
+
+import org.immutables.gson.Gson;
+
+public interface Timestamp extends SignedTufMeta<TufMeta>{
+
+  @Override
+  @Gson.Named("signed")
+  SnapshotMeta getSignedMeta();
+}


### PR DESCRIPTION
The lower level method needs to stay for both testing and verifying sub-delegates that can occur in targets.json.