### PR TITLE
Update go version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Go environment
       uses: actions/setup-go@v3.3.0
       with:
-        go-version: '1.17.x'
+        go-version: '1.19.x'
 
     # at some point this should just be replaced with something that can bring up a sigstore test env
     - name: Install Fulcio


### PR DESCRIPTION
Signed-off-by: Appu <appu@google.com>

Fulcio required a newer version of go.