### PR TITLE
chore: fix deprecated set-output call

### DIFF
--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -65,7 +65,7 @@ jobs:
         id: hash
         run: |
           cd build/release
-          echo "::set-output name=hashes::$(sha256sum ./* | base64 -w0)"
+          echo "hashes=$(sha256sum ./* | base64 -w0)" >> $GITHUB_OUTPUT
           sha256sum ./*
 
       - name: Upload build artifacts


### PR DESCRIPTION
[GitHub deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the 'set-output' command; this updates the build to use the newly supported method.

Signed-off-by: Bob Callaway <bcallaway@google.com>
