### PR TITLE
refactor tufclient to updater (its true role) and pass metadata as ar…

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFileExceedsMaxException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFileExceedsMaxException.java
@@ -17,7 +17,7 @@ package dev.sigstore.tuf;
 
 /**
  * Thrown when the Meta File exceeds the max allowable file size as configured in the {@link
- * TufClient}
+ * Updater}
  */
 public class MetaFileExceedsMaxException extends TufException {
 

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
@@ -43,7 +43,7 @@ class FileSystemTufStoreTest {
   void setTrustedRoot_noPrevious(@TempDir Path repoBase) throws IOException {
     TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertFalse(repoBase.resolve("root.json").toFile().exists());
-    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
+    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.UPDATER_TRUSTED_ROOT));
     assertEquals(1, repoBase.toFile().list().length);
     assertTrue(repoBase.resolve("root.json").toFile().exists());
   }
@@ -55,7 +55,7 @@ class FileSystemTufStoreTest {
     TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
     int version = tufLocalStore.loadTrustedRoot().get().getSignedMeta().getVersion();
     assertFalse(repoBase.resolve(version + ".root.json").toFile().exists());
-    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.CLIENT_TRUSTED_ROOT));
+    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.UPDATER_TRUSTED_ROOT));
     assertTrue(repoBase.resolve(version + ".root.json").toFile().exists());
   }
 

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
@@ -152,7 +152,7 @@ class UpdaterTest {
 
   @Test
   public void testTimestampUpdate_throwMetaNotFoundException() throws IOException {
-    setupMirror("remote-timestamp-not-present");
+    setupMirror("remote-timestamp-not-present", "2.root.json", "3.root.json");
     var updater = createTimeStaticUpdater(localStore);
     assertThrows(
         MetaNotFoundException.class,

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
@@ -51,13 +51,13 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 
-class TufClientTest {
+class UpdaterTest {
 
   public static final String TEST_STATIC_UPDATE_TIME = "2022-09-09T13:37:00.00Z";
 
   static Server remote;
   static String remoteUrl;
-  private static final Path trustedRoot = TestResources.CLIENT_TRUSTED_ROOT;
+  private static final Path trustedRoot = TestResources.UPDATER_TRUSTED_ROOT;
   @TempDir Path localStore;
   @TempDir static Path localMirror;
   Path tufTestData = Paths.get("src/test/resources/dev/sigstore/tuf/");
@@ -82,8 +82,8 @@ class TufClientTest {
   public void testRootUpdate_fromProdData()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-repo-prod", "1.root.json", "2.root.json", "3.root.json", "4.root.json");
-    var client = createTimeStaticTufClient(localStore);
-    client.updateRoot();
+    var updater = createTimeStaticUpdater(localStore);
+    updater.updateRoot();
     assertStoreContains("root.json");
     Root oldRoot = TestResources.loadRoot(trustedRoot);
     Root newRoot = TestResources.loadRoot(localStore.resolve("root.json"));
@@ -95,9 +95,9 @@ class TufClientTest {
   public void testRootUpdate_notEnoughSignatures()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-repo-unsigned", "2.root.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
+      updater.updateRoot();
       fail(
           "SignastureVerificationException was expected as 0 verification signatures should be present.");
     } catch (SignatureVerificationException e) {
@@ -110,9 +110,9 @@ class TufClientTest {
   public void testRootUpdate_expiredRoot()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-repo-expired", "2.root.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
+      updater.updateRoot();
       fail("The remote repo should be expired and cause a RoleExpiredException.");
     } catch (RoleExpiredException e) {
       assertEquals(ZonedDateTime.parse(TEST_STATIC_UPDATE_TIME), e.getUpdateTime());
@@ -127,9 +127,9 @@ class TufClientTest {
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException,
           SignatureVerificationException {
     setupMirror("remote-repo-inconsistent-version", "2.root.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
+      updater.updateRoot();
       fail("RoleVersionException expected fetching 2.root.json with a version field set to 3.");
     } catch (RoleVersionException e) {
       assertEquals(2, e.getExpectedVersion(), "expected root version");
@@ -141,9 +141,9 @@ class TufClientTest {
   public void testRootUpdate_metaFileTooBig()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-repo-meta-file-too-big", "2.root.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
+      updater.updateRoot();
       fail("MetaFileExceedsMaxException expected as 2.root.json is larger than max allowable.");
     } catch (MetaFileExceedsMaxException e) {
       // expected
@@ -153,18 +153,21 @@ class TufClientTest {
   @Test
   public void testTimestampUpdate_throwMetaNotFoundException() throws IOException {
     setupMirror("remote-timestamp-not-present");
-    var client = createTimeStaticTufClient(localStore);
-    assertThrows(MetaNotFoundException.class, client::updateTimestamp);
+    var updater = createTimeStaticUpdater(localStore);
+    assertThrows(
+        MetaNotFoundException.class,
+        () -> {
+          updater.updateTimestamp(updater.updateRoot());
+        });
   }
 
   @Test
   public void testTimestampUpdate_throwsSignatureVerificationException()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-timestamp-unsigned", "2.root.json", "3.root.json", "timestamp.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
-      client.updateTimestamp();
+      updater.updateTimestamp(updater.updateRoot());
       fail("The timestamp was not signed so should have thown a SignatureVerificationException.");
     } catch (SignatureVerificationException e) {
       assertEquals(0, e.getVerifiedSignatures(), "verified signature threshold did not match");
@@ -178,10 +181,9 @@ class TufClientTest {
     bootstrapLocalStore(localStore, "remote-repo-prod", "2.root.json", "timestamp.json");
     setupMirror(
         "remote-timestamp-rollback-version", "2.root.json", "3.root.json", "timestamp.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
-      client.updateTimestamp();
+      updater.updateTimestamp(updater.updateRoot());
       fail(
           "The repo in this test provides an older signed timestamp version that should have caused a RoleVersionException.");
     } catch (RoleVersionException e) {
@@ -194,10 +196,9 @@ class TufClientTest {
   public void testTimestampUpdate_throwsRoleExpiredException()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-timestamp-expired", "2.root.json", "3.root.json", "timestamp.json");
-    var client = createTimeStaticTufClient(localStore);
+    var updater = createTimeStaticUpdater(localStore);
     try {
-      client.updateRoot();
-      client.updateTimestamp();
+      updater.updateTimestamp(updater.updateRoot());
       fail("Expects a RoleExpiredException as the repo timestamp.json should be expired.");
     } catch (RoleExpiredException e) {
       // expected.
@@ -209,13 +210,12 @@ class TufClientTest {
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     bootstrapLocalStore(localStore, "remote-repo-prod", "2.root.json", "timestamp.json");
     setupMirror("remote-timestamp-valid", "2.root.json", "3.root.json", "timestamp.json");
-    var client = createTimeStaticTufClient(localStore);
-    client.updateRoot();
-    client.updateTimestamp();
+    var updater = createTimeStaticUpdater(localStore);
+    updater.updateTimestamp(updater.updateRoot());
     assertStoreContains("timestamp.json");
     assertEquals(
         52,
-        client.getLocalStore().loadTimestamp().get().getSignedMeta().getVersion(),
+        updater.getLocalStore().loadTimestamp().get().getSignedMeta().getVersion(),
         "timestamp version did not match expectations");
   }
 
@@ -223,13 +223,12 @@ class TufClientTest {
   public void testTimestampUpdate_updateExistingTimestamp_success()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     setupMirror("remote-timestamp-valid", "2.root.json", "3.root.json", "timestamp.json");
-    var client = createTimeStaticTufClient(localStore);
-    client.updateRoot();
-    client.updateTimestamp();
+    var updater = createTimeStaticUpdater(localStore);
+    updater.updateTimestamp(updater.updateRoot());
     assertStoreContains("timestamp.json");
     assertEquals(
         52,
-        client.getLocalStore().loadTimestamp().get().getSignedMeta().getVersion(),
+        updater.getLocalStore().loadTimestamp().get().getSignedMeta().getVersion(),
         "timestamp version did not match expectations.");
   }
 
@@ -290,8 +289,7 @@ class TufClientTest {
             .build();
     byte[] verificationMaterial = "alksdjfas".getBytes(StandardCharsets.UTF_8);
 
-    createAlwaysVerifyingTufClient()
-        .verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
+    createAlwaysVerifyingUpdater().verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
     // we are good
   }
 
@@ -303,9 +301,9 @@ class TufClientTest {
     Map<String, Key> publicKeys = ImmutableMap.of(PUB_KEY_1.getLeft(), PUB_KEY_1.getRight());
     Role delegate = ImmutableRootRole.builder().addKeyids(PUB_KEY_1.getLeft()).threshold(1).build();
     byte[] verificationMaterial = "alksdjfas".getBytes(StandardCharsets.UTF_8);
-    var client = TufClient.builder().setVerifiers(ALWAYS_FAILS).build();
+    var updater = Updater.builder().setVerifiers(ALWAYS_FAILS).build();
     try {
-      client.verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
+      updater.verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
       fail("This should have failed since the public key for PUB_KEY_1 should fail to verify.");
     } catch (SignatureVerificationException e) {
       assertEquals(
@@ -328,7 +326,7 @@ class TufClientTest {
     byte[] verificationMaterial = "alksdjfas".getBytes(StandardCharsets.UTF_8);
 
     try {
-      createAlwaysVerifyingTufClient()
+      createAlwaysVerifyingUpdater()
           .verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
       fail(
           "Test should have thrown SignatureVerificationException due to insufficient public keys");
@@ -350,7 +348,7 @@ class TufClientTest {
     byte[] verificationMaterial = "alksdjfas".getBytes(StandardCharsets.UTF_8);
 
     try {
-      createAlwaysVerifyingTufClient()
+      createAlwaysVerifyingUpdater()
           .verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
       fail(
           "Test should have thrown SignatureVerificationException due to insufficient public keys");
@@ -378,7 +376,7 @@ class TufClientTest {
     byte[] verificationMaterial = "alksdjfas".getBytes(StandardCharsets.UTF_8);
 
     try {
-      createAlwaysVerifyingTufClient()
+      createAlwaysVerifyingUpdater()
           .verifyDelegate(sigs, publicKeys, delegate, verificationMaterial);
       fail(
           "Test should have thrown SignatureVerificationException due to insufficient public keys");
@@ -401,8 +399,8 @@ class TufClientTest {
   }
 
   @NotNull
-  private static TufClient createTimeStaticTufClient(Path localStore) throws IOException {
-    return TufClient.builder()
+  private static Updater createTimeStaticUpdater(Path localStore) throws IOException {
+    return Updater.builder()
         .setClock(Clock.fixed(Instant.parse(TEST_STATIC_UPDATE_TIME), ZoneOffset.UTC))
         .setVerifiers(Verifiers::newVerifier)
         .setFetcher(HttpMetaFetcher.newFetcher(new URL(remoteUrl)))
@@ -412,8 +410,8 @@ class TufClientTest {
   }
 
   @NotNull
-  private static TufClient createAlwaysVerifyingTufClient() {
-    return TufClient.builder().setVerifiers(ALWAYS_VERIFIES).build();
+  private static Updater createAlwaysVerifyingUpdater() {
+    return Updater.builder().setVerifiers(ALWAYS_VERIFIES).build();
   }
 
   private static void setupMirror(String repoName, String... files) throws IOException {

--- a/sigstore-java/src/test/resources/dev/sigstore/tuf/remote-timestamp-not-present/2.root.json
+++ b/sigstore-java/src/test/resources/dev/sigstore/tuf/remote-timestamp-not-present/2.root.json
@@ -1,0 +1,144 @@
+{
+	"signatures": [
+		{
+			"keyid": "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+			"sig": "3046022100d3ea59490b253beae0926c6fa63f54336dea1ed700555be9f27ff55cd347639c0221009157d1ba012cead81948a4ab777d355451d57f5c4a2d333fc68d2e3f358093c2"
+		},
+		{
+			"keyid": "bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+			"sig": "304502206eaef40564403ce572c6d062e0c9b0aab5e0223576133e081e1b495e8deb9efd02210080fd6f3464d759601b4afec596bbd5952f3a224cd06ed1cdfc3c399118752ba2"
+		},
+		{
+			"keyid": "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+			"sig": "304502207baace02f56d8e6069f10b6ff098a26e7f53a7f9324ad62cffa0557bdeb9036c022100fb3032baaa090d0040c3f2fd872571c84479309b773208601d65948df87a9720"
+		},
+		{
+			"keyid": "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+			"sig": "304402205180c01905505dd88acd7a2dad979dd75c979b3722513a7bdedac88c6ae8dbeb022056d1ddf7a192f0b1c2c90ff487de2fb3ec9f0c03f66ea937c78d3b6a493504ca"
+		},
+		{
+			"keyid": "f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209",
+			"sig": "3046022100c8806d4647c514d80fd8f707d3369444c4fd1d0812a2d25f828e564c99790e3f022100bb51f12e862ef17a7d3da2ac103bebc5c7e792237006c4cafacd76267b249c2f"
+		}
+	],
+	"signed": {
+		"_type": "root",
+		"consistent_snapshot": false,
+		"expires": "2022-05-11T19:09:02.663975009Z",
+		"keys": {
+			"2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"b6710623a30c010738e64c5209d367df1c0a18cf90e6ab5292fb01680f83453d": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04fa1a3e42f2300cd3c5487a61509348feb1e936920fef2f83b7cd5dbe7ba045f538725ab8f18a666e6233edb7e0db8766c8dc336633449c5e1bbe0c182b02df0b"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04a71aacd835dc170ba6db3fa33a1a33dee751d4f8b0217b805b9bd3242921ee93672fdcfd840576c5bb0dc0ed815edf394c1ee48c2b5e02485e59bfc512f3adc7"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04117b33dd265715bf23315e368faa499728db8d1f0a377070a1c7b1aba2cc21be6ab1628e42f2cdd7a35479f2dce07b303a8ba646c55569a8d2a504ba7e86e447"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04cc1cd53a61c23e88cc54b488dfae168a257c34fac3e88811c55962b24cffbfecb724447999c54670e365883716302e49da57c79a33cd3e16f81fbc66f0bcdf48"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "048a78a44ac01099890d787e5e62afc29c8ccb69a70ec6549a6b04033b0a8acbfb42ab1ab9c713d225cdb52b858886cf46c8e90a7f3b9e6371882f370c259e1c5b"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"fc61191ba8a516fe386c7d6c97d918e1d241e1589729add09b122725b8c32451": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "044c7793ab74b9ddd713054e587b8d9c75c5f6025633d0fef7ca855ed5b8d5a474b23598fe33eb4a63630d526f74d4bdaec8adcb51993ed65652d651d7c49203eb"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			}
+		},
+		"roles": {
+			"root": {
+				"keyids": [
+					"2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+					"bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+					"eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+					"f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+					"f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+				],
+				"threshold": 3
+			},
+			"snapshot": {
+				"keyids": [
+					"fc61191ba8a516fe386c7d6c97d918e1d241e1589729add09b122725b8c32451"
+				],
+				"threshold": 1
+			},
+			"targets": {
+				"keyids": [
+					"2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+					"bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+					"eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+					"f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+					"f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+				],
+				"threshold": 3
+			},
+			"timestamp": {
+				"keyids": [
+					"b6710623a30c010738e64c5209d367df1c0a18cf90e6ab5292fb01680f83453d"
+				],
+				"threshold": 1
+			}
+		},
+		"spec_version": "1.0",
+		"version": 2
+	}
+}

--- a/sigstore-java/src/test/resources/dev/sigstore/tuf/remote-timestamp-not-present/3.root.json
+++ b/sigstore-java/src/test/resources/dev/sigstore/tuf/remote-timestamp-not-present/3.root.json
@@ -1,0 +1,136 @@
+{
+	"signatures": [
+		{
+			"keyid": "2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+			"sig": "3046022100e7a80e4b03eb8768999d20f104925fd9149faf3f6f73ee80f8c2e8d5f998f48c022100d3f01eb8effee202a244e710dca09530b9c57c5e510ab35172bd5eddd373ccc8"
+		},
+		{
+			"keyid": "eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+			"sig": "304502200e45fde5cf750f8c533c4f259eb1469510600993b98ae2c3cb8f1922cda96e27022100f5151760d0ef0882a96c2531ccd9f5e4a7ff2b259d8eb34ead8bfdf60cb52fee"
+		},
+		{
+			"keyid": "f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+			"sig": "304502205a7ebeac3617bfb1aca957a6f74d37a02f2854afa54e5103fb3c891bb25836db022100f06614ca8d21f968e45edc29f826d8dbeed07c51d4cb473a734a2036171900de"
+		}
+	],
+	"signed": {
+		"_type": "root",
+		"consistent_snapshot": false,
+		"expires": "2022-11-10T21:58:09.733402317Z",
+		"keys": {
+			"2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04cbc5cab2684160323c25cd06c3307178a6b1d1c9b949328453ae473c5ba7527e35b13f298b41633382241f3fd8526c262d43b45adee5c618fa0642c82b8a9803"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"b6710623a30c010738e64c5209d367df1c0a18cf90e6ab5292fb01680f83453d": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04fa1a3e42f2300cd3c5487a61509348feb1e936920fef2f83b7cd5dbe7ba045f538725ab8f18a666e6233edb7e0db8766c8dc336633449c5e1bbe0c182b02df0b"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04a71aacd835dc170ba6db3fa33a1a33dee751d4f8b0217b805b9bd3242921ee93672fdcfd840576c5bb0dc0ed815edf394c1ee48c2b5e02485e59bfc512f3adc7"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04117b33dd265715bf23315e368faa499728db8d1f0a377070a1c7b1aba2cc21be6ab1628e42f2cdd7a35479f2dce07b303a8ba646c55569a8d2a504ba7e86e447"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "04cc1cd53a61c23e88cc54b488dfae168a257c34fac3e88811c55962b24cffbfecb724447999c54670e365883716302e49da57c79a33cd3e16f81fbc66f0bcdf48"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "048a78a44ac01099890d787e5e62afc29c8ccb69a70ec6549a6b04033b0a8acbfb42ab1ab9c713d225cdb52b858886cf46c8e90a7f3b9e6371882f370c259e1c5b"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			},
+			"fc61191ba8a516fe386c7d6c97d918e1d241e1589729add09b122725b8c32451": {
+				"keyid_hash_algorithms": [
+					"sha256",
+					"sha512"
+				],
+				"keytype": "ecdsa-sha2-nistp256",
+				"keyval": {
+					"public": "044c7793ab74b9ddd713054e587b8d9c75c5f6025633d0fef7ca855ed5b8d5a474b23598fe33eb4a63630d526f74d4bdaec8adcb51993ed65652d651d7c49203eb"
+				},
+				"scheme": "ecdsa-sha2-nistp256"
+			}
+		},
+		"roles": {
+			"root": {
+				"keyids": [
+					"2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+					"bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+					"eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+					"f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+					"f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+				],
+				"threshold": 3
+			},
+			"snapshot": {
+				"keyids": [
+					"fc61191ba8a516fe386c7d6c97d918e1d241e1589729add09b122725b8c32451"
+				],
+				"threshold": 1
+			},
+			"targets": {
+				"keyids": [
+					"2f64fb5eac0cf94dd39bb45308b98920055e9a0d8e012a7220787834c60aef97",
+					"bdde902f5ec668179ff5ca0dabf7657109287d690bf97e230c21d65f99155c62",
+					"eaf22372f417dd618a46f6c627dbc276e9fd30a004fc94f9be946e73f8bd090b",
+					"f40f32044071a9365505da3d1e3be6561f6f22d0e60cf51df783999f6c3429cb",
+					"f505595165a177a41750a8e864ed1719b1edfccd5a426fd2c0ffda33ce7ff209"
+				],
+				"threshold": 3
+			},
+			"timestamp": {
+				"keyids": [
+					"b6710623a30c010738e64c5209d367df1c0a18cf90e6ab5292fb01680f83453d"
+				],
+				"threshold": 1
+			}
+		},
+		"spec_version": "1.0",
+		"version": 3
+	}
+}

--- a/sigstore-testkit/src/main/java/dev/sigstore/testkit/tuf/TestResources.java
+++ b/sigstore-testkit/src/main/java/dev/sigstore/testkit/tuf/TestResources.java
@@ -25,8 +25,8 @@ import java.nio.file.Path;
 
 public class TestResources {
 
-  public static final Path CLIENT_TRUSTED_ROOT = Path.of(Resources.getResource("dev/sigstore/tuf/trusted-root.json").getPath());
-  public static final Path TUF_TEST_DATA_DIRECTORY = CLIENT_TRUSTED_ROOT.getParent();
+  public static final Path UPDATER_TRUSTED_ROOT = Path.of(Resources.getResource("dev/sigstore/tuf/trusted-root.json").getPath());
+  public static final Path TUF_TEST_DATA_DIRECTORY = UPDATER_TRUSTED_ROOT.getParent();
 
   public static void setupRepoFiles(String repoName, Path destinationDir, String... files)
       throws IOException {


### PR DESCRIPTION
Progress towards #60 .

TufClient has always been a placeholder class to start on TUF update algorithm. As the class is designed it's not appropriately scoped as a TUF client will exist at the map.json scope which can include N number of remote mirrors to manage.   Renaming the class to Updater clarifies its role with the client code.

Passing the trusted resources as inputs to subsequent update steps that require them is more efficient and clear than having each update step reload that resource from the store.
