### PR TITLE
add the raw bytes to fetcher result so that we can do things like che…

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetchResult.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetchResult.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import dev.sigstore.tuf.model.SignedTufMeta;
+
+/**
+ * Result object returned by {@link MetaFetcher} interface.
+ *
+ * @param <T>
+ */
+public class MetaFetchResult<T extends SignedTufMeta> {
+  private byte[] rawBytes;
+  private T metaResource;
+
+  public MetaFetchResult(byte[] rawBytes, T metaResource) {
+    this.rawBytes = rawBytes;
+    this.metaResource = metaResource;
+  }
+
+  /** The resources raw bytes received from the mirror. */
+  public byte[] getRawBytes() {
+    return rawBytes;
+  }
+
+  /** The hydrated object from the bytestrema. */
+  public T getMetaResource() {
+    return metaResource;
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
@@ -17,6 +17,7 @@ package dev.sigstore.tuf;
 
 import dev.sigstore.tuf.model.Role;
 import dev.sigstore.tuf.model.Root;
+import dev.sigstore.tuf.model.SignedTufMeta;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -35,7 +36,8 @@ public interface MetaFetcher {
    * @throws MetaFileExceedsMaxException when the retrieved file is larger than the maximum allowed
    *     by the client
    */
-  Optional<Root> getRootAtVersion(int version) throws IOException, MetaFileExceedsMaxException;
+  Optional<MetaFetchResult<Root>> getRootAtVersion(int version)
+      throws IOException, MetaFileExceedsMaxException;
 
   /**
    * Fetches the specified role meta from the source
@@ -47,6 +49,6 @@ public interface MetaFetcher {
    * @throws MetaFileExceedsMaxException if the role meta at source exceeds client specified max
    *     size
    */
-  <T> Optional<T> getMeta(Role.Name name, Class<T> roleType)
+  <T extends SignedTufMeta> Optional<MetaFetchResult<T>> getMeta(Role.Name name, Class<T> roleType)
       throws IOException, MetaFileExceedsMaxException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -109,7 +109,7 @@ public class Updater {
         // No newer versions, go to 5.3.10.
         break;
       }
-      var newRoot = newRootMaybe.get();
+      var newRoot = newRootMaybe.get().getMetaResource();
       // 5.3.4) we have a valid next version of the root.json. Check that the file has been signed
       // by:
       //   a) a threshold (from step 2) of keys specified in the trusted metadata
@@ -226,7 +226,8 @@ public class Updater {
         fetcher
             .getMeta(Role.Name.TIMESTAMP, Timestamp.class)
             .orElseThrow(
-                () -> new MetaNotFoundException("could not find timestamp.json on mirror."));
+                () -> new MetaNotFoundException("could not find timestamp.json on mirror."))
+            .getMetaResource();
 
     // 2) verify against threshold of keys as specified in trusted root.json
     verifyDelegate(root, timestamp);


### PR DESCRIPTION
related to #60 

It's convenient to actually keep a reference to the original bytes retrieved from the mirror so that we can use them for checksum checks as well as potentially store them directly to the local store rather than deserializing and serializing which could potentially introduce differences between the local cache and mirror. 