### PR TITLE
Add Error Prone verifications

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
     implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:1.4.32")
     implementation("com.github.autostyle:com.github.autostyle.gradle.plugin:3.2")
+    implementation("net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:3.0.1")
 }

--- a/build-logic/jvm/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -1,0 +1,29 @@
+import net.ltgt.gradle.errorprone.errorprone
+
+plugins {
+    java
+}
+
+if (!project.hasProperty("skipErrorprone")) {
+    apply(plugin = "net.ltgt.errorprone")
+
+    dependencies {
+        "errorprone"("com.google.errorprone:error_prone_core:2.16")
+        "annotationProcessor"("com.google.guava:guava-beta-checker:1.0")
+    }
+
+    tasks.withType<JavaCompile>().configureEach {
+        if ("Test" in name) {
+            // Ignore warnings in test code
+            options.errorprone.isEnabled.set(false)
+        } else {
+            options.compilerArgs.addAll(listOf("-Xmaxerrs", "10000", "-Xmaxwarns", "10000"))
+            options.errorprone {
+                disableWarningsInGeneratedCode.set(true)
+                enable(
+                    "PackageLocation"
+                )
+            }
+        }
+    }
+}

--- a/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     `java-base`
     id("com.github.vlsi.gradle-extensions")
     id("build-logic.testing")
+    id("build-logic.errorprone")
 }
 
 java {

--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -61,6 +61,12 @@ protobuf {
             plugins {
                 id("grpc")
             }
+            builtins {
+                named("java") {
+                    // Adds @javax.annotation.Generated annotation to the generated code
+                    option("annotate_code")
+                }
+            }
         }
     }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
@@ -164,6 +164,7 @@ public class FulcioVerifier {
     pkixParams.setRevocationEnabled(false);
 
     // these certs are only valid for 15 minutes, so find a time in the validity period
+    @SuppressWarnings("JavaUtilDate")
     Date dateInValidityPeriod =
         new Date(signingCertificate.getLeafCertificate().getNotBefore().getTime());
     pkixParams.setDate(dateInValidityPeriod);

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
@@ -145,7 +145,8 @@ public class SigningCertificate {
       }
       if (extensions.length != 0) {
         throw new JsonParseException(
-            "SCT has extensions that cannot be handled by client:" + new String(extensions));
+            "SCT has extensions that cannot be handled by client:"
+                + new String(extensions, StandardCharsets.UTF_8));
       }
 
       DigitallySigned digiSig = DigitallySigned.decode(signature);

--- a/sigstore-java/src/main/java/dev/sigstore/json/GsonSupplier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/json/GsonSupplier.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 public enum GsonSupplier implements Supplier<Gson> {
   GSON;
 
+  @SuppressWarnings("ImmutableEnumChecker")
   private final Gson gson =
       new GsonBuilder()
           .registerTypeAdapter(byte[].class, new GsonByteArrayAdapter())

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
@@ -117,6 +117,7 @@ public class WebOidcClient implements OidcClient {
    * @return an openid token with additional email scopes
    * @throws OidcException if an error occurs doing the authorization flow
    */
+  @Override
   public OidcToken getIDToken() throws OidcException {
     JsonFactory jsonFactory = new GsonFactory();
     HttpTransport httpTransport = HttpClients.newHttpTransport(httpParams);

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/HashedRekordRequest.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/HashedRekordRequest.java
@@ -52,7 +52,8 @@ public class HashedRekordRequest {
                 new Data()
                     .withHash(
                         new Hash()
-                            .withValue(new String(Hex.encode(artifactDigest)))
+                            .withValue(
+                                new String(Hex.encode(artifactDigest), StandardCharsets.ISO_8859_1))
                             .withAlgorithm(Hash.Algorithm.SHA_256)))
             .withSignature(
                 new Signature()

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -22,8 +22,8 @@ import dev.sigstore.tuf.model.Role;
 import dev.sigstore.tuf.model.Root;
 import dev.sigstore.tuf.model.SignedTufMeta;
 import dev.sigstore.tuf.model.Timestamp;
+import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -80,9 +80,9 @@ public class FileSystemTufStore implements TufLocalStore {
   }
 
   <T extends SignedTufMeta> void saveRole(T role) throws IOException {
-    try (FileWriter fileWriter =
-        new FileWriter(repoBaseDir.resolve(role.getSignedMeta().getType() + ".json").toFile())) {
-      fileWriter.write(GSON.get().toJson(role));
+    try (BufferedWriter fileWriter =
+        Files.newBufferedWriter(repoBaseDir.resolve(role.getSignedMeta().getType() + ".json"))) {
+      GSON.get().toJson(role, fileWriter);
     }
   }
 

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Delegations.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Delegations.java
@@ -21,6 +21,8 @@ import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 
 /**
+ * TUF Delegations.
+ *
  * @see <a href="https://theupdateframework.github.io/specification/latest/#delegations">TUF
  *     Delegation docs.</a>
  */


### PR DESCRIPTION
The verification is enabled by default, and it can be skipped via
 `-PskipErrorprone` or adding `skipErrorprone=true` to `$HOME/.gradle/gradle.properties`

Error Prone produces actionable warnings, so I suggest we enable it by default.

See https://errorprone.info/bugpatterns

Some of the "experimental" patterns might be worth adding as well.

For instance,
* https://errorprone.info/bugpattern/FieldCanBeFinal
* https://errorprone.info/bugpattern/MethodCanBeStatic

`FieldCanBeFinal` yields several warnings in TUF code, so I did not enable it to avoid conflicts with @patflynn.
