### PR TITLE
Use embedded-in-gradle-kotlin compiler version instead of hard-coded one

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     // It does not support participating in precompiled script plugins
     id("com.github.vlsi.stage-vote-release") version "1.84"
     // The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
-    kotlin("jvm") version "1.5.31" apply false
+    `embedded-kotlin` apply false
 }
 
 val buildVersion = "${findProperty("version")}${releaseParams.snapshotSuffix}"


### PR DESCRIPTION
#### Summary

It unblocks upgrading Gradle as different Gradle embedd different Kotlin, so we should use the actually embedded one.

It would unblock https://github.com/sigstore/sigstore-java/pull/242

#### Release Note

NONE

#### Documentation

NONE
