### PR TITLE
Use the Dokka version as the embedded in Gradle Kotlin version

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.12.0")
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.84")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:1.4.32")
+    implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:$embeddedKotlinVersion")
     implementation("com.github.autostyle:com.github.autostyle.gradle.plugin:3.2")
     implementation("net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:3.0.1")
 }


### PR DESCRIPTION
#### Summary

We use embedded Kotlin for plugin, so Dokka should be the same otherwise it might fail to work

#### Release Note

NONE

#### Documentation

NONE