### PR TITLE
Support Gradle Plugin testing with locally-built sigstore-java

### DIFF
--- a/build-logic/publishing/src/main/kotlin/build-logic.kotlin-dsl-published-gradle-plugin.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.kotlin-dsl-published-gradle-plugin.gradle.kts
@@ -7,3 +7,39 @@ plugins {
     id("build-logic.dokka-javadoc")
     id("build-logic.publish-to-central")
 }
+
+val sigstoreJavaRuntime by configurations.creating {
+    description = "declares dependencies that will be useful for testing purposes"
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+
+val sigstoreJavaTestClasspath by configurations.creating {
+    description = "sigstore-java in local repository for testing purposes"
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    extendsFrom(sigstoreJavaRuntime)
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named("maven-repository"))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    }
+}
+
+tasks.test {
+    dependsOn(sigstoreJavaTestClasspath)
+    systemProperty("sigstore.test.current.version", version)
+    val projectDir = layout.projectDirectory.asFile
+    // This adds paths to the local repositories that contain currently-built sigstore-java
+    // It enables testing both "sigstore-java from Central" and "sigstore-java build locally" in the plugin tests
+    jvmArgumentProviders.add(
+        // Gradle does not support Provider for systemProperties yet, see https://github.com/gradle/gradle/issues/12247
+        CommandLineArgumentProvider {
+            listOf(
+                "-Dsigstore.test.local.maven.repo=" +
+                        sigstoreJavaTestClasspath.joinToString(File.pathSeparator) {
+                            it.toRelativeString(projectDir)
+                        }
+            )
+        }
+    )
+}

--- a/build-logic/publishing/src/main/kotlin/build-logic.publish-to-central.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.publish-to-central.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.publish.internal.PublicationInternal
 plugins {
     id("java-library")
     id("maven-publish")
+    id("build-logic.publish-to-tmp-maven-repo")
 }
 
 val repoUrl = "https://github.com/sigstore/sigstore-java"

--- a/build-logic/publishing/src/main/kotlin/build-logic.publish-to-tmp-maven-repo.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.publish-to-tmp-maven-repo.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    id("java-library")
+    id("maven-publish")
+}
+
+val localRepoElements by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    description =
+        "Shares local maven repository directory that contains the artifacts produced by the current project"
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named("maven-repository"))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    }
+}
+
+val localRepoDir = layout.buildDirectory.dir("local-maven-repo")
+
+publishing {
+    repositories {
+        maven {
+            name = "tmp-maven"
+            url = uri(localRepoDir)
+        }
+    }
+}
+
+localRepoElements.outgoing.artifact(localRepoDir) {
+    builtBy(tasks.named("publishAllPublicationsToTmp-mavenRepository"))
+}
+
+val cleanLocalRepository by tasks.registering(Delete::class) {
+    description = "Clears local-maven-repo so timestamp-based snapshot artifacts do not consume space"
+    delete(localRepoDir)
+}
+
+tasks.withType<PublishToMavenRepository>()
+    .matching { it.name.endsWith("PublicationToTmp-mavenRepository") }
+    .configureEach {
+        dependsOn(cleanLocalRepository)
+    }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/build.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     compileOnly(project(":sigstore-java"))
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.1")
 
+    sigstoreJavaRuntime(project(":sigstore-java")) {
+        because("Test code needs access locally-built sigstore-java as a Maven repository")
+    }
     testImplementation(project(":sigstore-testkit"))
 }
 

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
@@ -43,5 +43,6 @@ val sigstoreClientClasspath by configurations.creating {
         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, LibraryElements.JAR)
         attribute(Usage.USAGE_ATTRIBUTE, Usage.JAVA_RUNTIME)
         attribute(Bundling.BUNDLING_ATTRIBUTE, Bundling.EXTERNAL)
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInt())
     }
 }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/OidcDslTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/OidcDslTest.kt
@@ -17,13 +17,14 @@
 package dev.sigstore.gradle
 
 import dev.sigstore.testkit.BaseGradleTest
+import dev.sigstore.testkit.TestedGradle
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 class OidcDslTest: BaseGradleTest() {
     @ParameterizedTest
     @MethodSource("gradleVersionAndSettings")
-    fun `configure GitHub OIDC client explicitly`(gradleVersion: String, configurationCache: ConfigurationCache) {
+    fun `configure GitHub OIDC client explicitly`(gradle: TestedGradle) {
         writeBuildGradle(
             """
             plugins {
@@ -44,8 +45,8 @@ class OidcDslTest: BaseGradleTest() {
             }
             """.trimIndent()
         )
-        enableConfigurationCache(gradleVersion, configurationCache)
-        prepare(gradleVersion, "printConfig", "-s")
+        enableConfigurationCache(gradle)
+        prepare(gradle.version, "printConfig", "-s")
             .build()
     }
 }

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/build.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/build.gradle.kts
@@ -8,6 +8,10 @@ description = "Gradle plugin to that automatically signs all Publications in Sig
 dependencies {
     api(project(":sigstore-gradle:sigstore-gradle-sign-base-plugin"))
 
+    sigstoreJavaRuntime(project(":sigstore-java")) {
+        because("Test code needs access locally-built sigstore-java as a Maven repository")
+    }
+
     testImplementation(project(":sigstore-testkit"))
 }
 

--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -20,6 +20,13 @@ dependencies {
 
     implementation("io.github.erdtman:java-json-canonicalization:1.1")
 
+    implementation("dev.sigstore:protobuf-specs:0.0.1") {
+        because("It generates Sigstore Bundle file")
+    }
+    implementation("com.google.protobuf:protobuf-java-util:3.13.0") {
+        because("It converts protobuf to json")
+    }
+
     // grpc deps
     implementation(platform("io.grpc:grpc-bom:1.51.1"))
     implementation("io.grpc:grpc-protobuf")

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradle.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradle.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sigstore.testkit
+
+/**
+ * Lists Gradle versions and its configuration for backward compatibility testing of Sigstore Gradle plugin.
+ */
+data class TestedGradle(
+    val version: String,
+    val configurationCache: BaseGradleTest.ConfigurationCache
+)

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedSigstoreJava.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedSigstoreJava.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sigstore.testkit
+
+/**
+ * Lists sigstore-java versions for backward compatibility testing of Sigstore Gradle plugin.
+ */
+sealed class TestedSigstoreJava {
+    /**
+     * sigstore-java version is unset, so sigstore-gradle should use the default version that is bundled with the plugin.
+     */
+    object Default: TestedSigstoreJava() {
+        override fun toString() = "Default"
+    }
+
+    /**
+     * Configures sigstore-java version for testing with Sigstore Gradle plugin.
+     */
+    data class Version(
+        val version: String,
+    ): TestedSigstoreJava()
+}


### PR DESCRIPTION
#### Summary

The plugin runs with a separate build, so by default it uses mavenCentral only. However, we need to ensure the plugin is compatible with the main branch, so we publish sigstore-java to a temp folder, and use it as a repository in tests.

Ideally, we could parameterize over sigstore-java versions in the future, however, the currently published Central plugin does not support "building sigstore bundle", so a slightly better idea might be just requiring "matching" versions for now.

#### Release Note

NONE

#### Documentation

NONE