### PR TITLE
Reuse Fulcio certificates when the same signer is used multiple times

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
@@ -15,12 +15,20 @@
  *
  */
 import dev.sigstore.sign.SigstoreSignExtension
+import dev.sigstore.sign.services.SigstoreSigningService
 
 // https://github.com/gradle/gradle/pull/16627
 inline fun <reified T: Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
     attribute(attr, objects.named<T>(value))
 
 val sigstoreSign = extensions.create("sigstoreSign", SigstoreSignExtension::class, project)
+
+gradle.sharedServices.registerIfAbsent(SigstoreSigningService.SERVICE_NAME, SigstoreSigningService::class) {
+    parameters {
+        // Prevents concurrent execution of tasks that use the service, so we ensure there's only one signing task active at a time
+        maxParallelUsages.set(1)
+    }
+}
 
 val sigstoreClient by configurations.creating {
     description = "Declares sigstore client dependencies"

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/GitHubActionsOidc.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/GitHubActionsOidc.kt
@@ -40,4 +40,6 @@ abstract class GitHubActionsOidc @Inject constructor() : OidcClientConfiguration
         GithubActionsOidcClient.builder()
             .audience(audience.get())
             .build()
+
+    override fun key(): Any = audience.get()
 }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -48,7 +48,6 @@ abstract class SigstoreSignExtension(private val project: Project) {
 
     fun sign(publications: DomainObjectCollection<Publication>) {
         publications.all {
-            project.logger.lifecycle("Signing $this")
             sign(this)
         }
         publications.whenObjectRemoved {

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/WebOidc.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/WebOidc.kt
@@ -45,4 +45,6 @@ abstract class WebOidc @Inject constructor() : OidcClientConfiguration, Serializ
             .setClientId(clientId.get())
             .setIssuer(issuer.get())
             .build()
+
+    override fun key(): Any = Pair(clientId.get(), issuer.get())
 }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/services/SigstoreSigningService.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/services/SigstoreSigningService.kt
@@ -14,19 +14,20 @@
  * limitations under the License.
  *
  */
-package dev.sigstore.sign
+package dev.sigstore.sign.services
 
-import org.gradle.api.Named
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 
-interface OidcClientConfiguration : Named {
-    /**
-     * Creates OidcClient. The return type is [Any]
-     * since plugin code has only `compileOny` dependency on `sigstore-java`.
-     */
-    fun build(): Any
+/**
+ * The service enables to prevent concurrent execution of signing tasks from different projects.
+ *
+ */
+abstract class SigstoreSigningService: BuildService<SigstoreSigningService.Params> {
+    companion object {
+        const val SERVICE_NAME = "sigstoreJavaSigningService"
+    }
 
-    /**
-     * Returns object that can be used to compare this configuration with another one.
-     */
-    fun key(): Any
+    interface Params: BuildServiceParameters {
+    }
 }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/tasks/SigstoreSignFilesTask.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/tasks/SigstoreSignFilesTask.kt
@@ -19,6 +19,7 @@ package dev.sigstore.sign.tasks
 import dev.sigstore.sign.OidcClientConfiguration
 import dev.sigstore.sign.SigstoreSignExtension
 import dev.sigstore.sign.SigstoreSignature
+import dev.sigstore.sign.services.SigstoreSigningService
 import dev.sigstore.sign.work.SignWorkAction
 import org.gradle.api.Buildable
 import org.gradle.api.DefaultTask
@@ -28,6 +29,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.the
@@ -38,6 +40,38 @@ import javax.inject.Inject
 
 @DisableCachingByDefault(because = "Sigstore signatures are true-timestamp dependent, so we should not cache signatures")
 abstract class SigstoreSignFilesTask : DefaultTask() {
+    companion object {
+        private val PROPERTY_SET_PROVIDER = Property::class.java.getMethod("set", Provider::class.java)
+    }
+
+    init {
+        @Suppress("UNCHECKED_CAST")
+        val service: Provider<SigstoreSigningService> =
+            project.gradle.sharedServices.registrations[SigstoreSigningService.SERVICE_NAME].service as Provider<SigstoreSigningService>
+
+        // Use reflection to resolve set(Provider) vs set(Object) ambiguity
+        @Suppress("LeakingThis")
+        PROPERTY_SET_PROVIDER.invoke(signingService, service)
+        // See https://docs.gradle.org/current/userguide/build_services.html
+        @Suppress("LeakingThis")
+        usesService(service)
+
+        @Suppress("LeakingThis")
+        passEnvironmentVariables.addAll(
+            "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+            "ACTIONS_ID_TOKEN_REQUEST_URL",
+        )
+    }
+
+    /**
+     * Signing service is there so none of the signing tasks execute concurrently.
+     * It reduces the number of OIDC flows, and it makes throttling Fulcio and Rekor requests easier.
+     *
+     * Type is `Any` to workaround https://github.com/gradle/gradle/issues/17559
+     */
+    @get:Internal
+    protected abstract val signingService: Property<Any>
+
     @Nested
     val signatures: NamedDomainObjectContainer<SigstoreSignature> =
         objects.domainObjectContainer(SigstoreSignature::class.java) {
@@ -68,6 +102,9 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
 
     @get:Inject
     protected abstract val layout: ProjectLayout
+
+    @get:Input
+    abstract val passEnvironmentVariables: SetProperty<String>
 
     init {
         outputs.upToDateWhen {
@@ -120,11 +157,15 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
 
     @TaskAction
     protected fun sign() {
+        // Ensure task holds a lock, so no other signign tasks executes concurrently
+        signingService.get()
         workerExecutor
             .processIsolation {
                 classpath.from(sigstoreClientClasspath)
                 forkOptions {
-                    environment(System.getenv())
+                    for (env in passEnvironmentVariables.get()) {
+                        System.getenv(env)?.let { environment(env, it) }
+                    }
                 }
             }
             .run {
@@ -134,8 +175,10 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
                         outputSignature.set(signature.outputSignature)
                         oidcClient.set(this@SigstoreSignFilesTask.oidcClient.get())
                     }
+                    // Wait after submitting each action, so the worker become active, and we can reuse it.
+                    // It enables reusing Fulcio certificates
+                    await()
                 }
-                await()
             }
     }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
@@ -29,7 +29,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Verifier for fulcio {@link dev.sigstore.fulcio.client.SigningCertificate}. */
 public class FulcioVerifier {
-  @Nullable private final CTVerifier ctVerifier;
+  private final @Nullable CTVerifier ctVerifier;
   private final TrustAnchor fulcioRoot;
 
   /**


### PR DESCRIPTION
This reduces the number of OIDC flows

Fixes https://github.com/sigstore/sigstore-java/issues/292

#### Summary

See:
* https://github.com/sigstore/sigstore-java/issues/292

I add `dev.sigstore.KeylessSigner.Builder#minSigningCertificateLifetime(Duration)`, and make it `5 minutes` by default.
In other words, if the time allows, then the signer will reuse the certificate.

#### Release Note

KeylessSigner reuses Fulcio certificate if its lifetime exceeds a configurable threshold.

#### Documentation

NONE