### PR TITLE
Avoid WorkValidationException when certain files do not exist for signing

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignature.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignature.kt
@@ -32,9 +32,9 @@ abstract class SigstoreSignature @Inject constructor(private val name: String) :
     @Internal
     override fun getName(): String = name
 
-    @get:InputFile
+    @get:InputFiles
     @get:PathSensitive(PathSensitivity.NONE)
-    abstract val file: RegularFileProperty
+    abstract val file: ConfigurableFileCollection
 
     /**
      * Adds the given build dependencies.
@@ -73,7 +73,7 @@ abstract class SigstoreSignature @Inject constructor(private val name: String) :
 
     init {
         outputSignature.convention(
-            signatureDirectory.map { it.file(file.get().asFile.name + ".$EXTENSION") }
+            signatureDirectory.map { it.file(file.singleFile.name + ".$EXTENSION") }
         )
     }
 }


### PR DESCRIPTION
#### Summary

Signing artifacts are generated for all the files (e.g. pom.xml, module.json, etc), however, if the task is disabled (e.g. someone disables Gradle Module Metadata), then module.json is not produced.

Gradle throws a validation error like "you are going to sign module.json, however, it is absent" Unfortunately, there's no easy way to include only those signing tasks that will be needed, so we generate signing tasks for all the files, and we just skip non-existing ones.

fixes https://github.com/sigstore/sigstore-java/issues/287

#### Release Note

NONE

#### Documentation

NONE