### PR TITLE
Ensure explicit locale is used instead of system default one, add forbidden-apis check

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(embeddedKotlinDsl())
     implementation("com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.13.0")
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.86")
+    implementation("de.thetaphi.forbiddenapis:de.thetaphi.forbiddenapis.gradle.plugin:3.4")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
     implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:$embeddedKotlinVersion")
     implementation("com.github.autostyle:com.github.autostyle.gradle.plugin:3.2")

--- a/build-logic/jvm/src/main/kotlin/build-logic.forbidden-apis.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.forbidden-apis.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("de.thetaphi.forbiddenapis")
+}
+
+forbiddenApis {
+    failOnUnsupportedJava = false
+    // ForbiddenApiException: Check for forbidden API calls failed while scanning class 'Dev_sigstore_sign_base_gradle'
+    // (dev.sigstore.sign-base.gradle.kts): java.lang.ClassNotFoundException: kotlin.script.experimental.jvm.RunnerKt
+    // (while looking up details about referenced class 'kotlin.script.experimental.jvm.RunnerKt')
+    failOnMissingClasses = false
+    // See https://github.com/policeman-tools/forbidden-apis/wiki/BundledSignatures
+    bundledSignatures.addAll(
+        listOf(
+            "jdk-deprecated",
+            "jdk-internal",
+            "jdk-non-portable",
+            "jdk-unsafe"
+        )
+    )
+}

--- a/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("build-logic.spotless-base")
     id("build-logic.testing")
     id("build-logic.errorprone")
+    id("build-logic.forbidden-apis")
 }
 
 java {

--- a/sigstore-conformance/src/main/java/dev/sigstore/conformance/Main.java
+++ b/sigstore-conformance/src/main/java/dev/sigstore/conformance/Main.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
 
 public class Main {
   private static final String SIGN_COMMAND = "sign";
@@ -63,7 +64,8 @@ public class Main {
     public String getNextArgument() {
       if (index >= args.length) {
         final var errorMsg =
-            String.format("Insufficient arguments; amount=%d, requested=%d", args.length, index);
+            String.format(
+                Locale.ROOT, "Insufficient arguments; amount=%d, requested=%d", args.length, index);
         throw new IllegalArgumentException(errorMsg);
       }
       return args[index++];
@@ -74,7 +76,10 @@ public class Main {
       if (!expectedArg.equals(nextArg)) {
         final var errorMsg =
             String.format(
-                "Found unexpected argument; expected=\"%s\", found=\"%s\"", expectedArg, nextArg);
+                Locale.ROOT,
+                "Found unexpected argument; expected=\"%s\", found=\"%s\"",
+                expectedArg,
+                nextArg);
         throw new IllegalArgumentException(errorMsg);
       }
     }

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.spec.*;
+import java.util.Locale;
 import java.util.logging.Logger;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -156,6 +157,7 @@ public class Keys {
     } else {
       String error =
           String.format(
+              Locale.ROOT,
               "The key provided was of type: %s. We only support RSA, EdDSA, and EC ",
               keyParameters);
       log.warning(error);

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/transparency/DigitallySigned.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/transparency/DigitallySigned.java
@@ -18,6 +18,7 @@ package dev.sigstore.encryption.certificates.transparency;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Locale;
 
 /** DigitallySigned structure, as defined by RFC5246 Section 4.7. */
 public class DigitallySigned {
@@ -93,7 +94,7 @@ public class DigitallySigned {
    * to {@link java.security.Signature#getInstance}.
    */
   public String getAlgorithm() {
-    return String.format("%swith%s", hashAlgorithm, signatureAlgorithm);
+    return String.format(Locale.ROOT, "%swith%s", hashAlgorithm, signatureAlgorithm);
   }
 
   /** Decode a TLS encoded DigitallySigned structure. */

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
@@ -37,6 +37,7 @@ import dev.sigstore.http.HttpParams;
 import dev.sigstore.http.ImmutableHttpParams;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * A client to obtain oidc tokens from an oauth provider via web workflow for use with sigstore. By
@@ -174,8 +175,10 @@ public class WebOidcClient implements OidcClient {
     if (Boolean.FALSE.equals(emailVerified)) {
       throw new OidcException(
           String.format(
+              Locale.ROOT,
               "identity provider '%s' reports email address '%s' has not been verified",
-              parsedIdToken.getPayload().getIssuer(), emailFromIDToken));
+              parsedIdToken.getPayload().getIssuer(),
+              emailFromIDToken));
     }
 
     return ImmutableOidcToken.builder()

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient.java
@@ -89,7 +89,10 @@ public class RekorClient {
     if (resp.getStatusCode() != 201) {
       throw new IOException(
           String.format(
-              "bad response from rekor @ '%s' : %s", rekorPutEndpoint, resp.parseAsString()));
+              Locale.ROOT,
+              "bad response from rekor @ '%s' : %s",
+              rekorPutEndpoint,
+              resp.parseAsString()));
     }
 
     URI rekorEntryUri = serverUrl.resolve(resp.getHeaders().getLocation());

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileExceedsMaxLengthException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileExceedsMaxLengthException.java
@@ -15,6 +15,8 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 /**
  * Thrown when the Meta File exceeds the max allowable file size as configured in the {@link
  * Updater}
@@ -27,7 +29,10 @@ public class FileExceedsMaxLengthException extends TufException {
   public FileExceedsMaxLengthException(String fileUrl, int maxSize) {
     super(
         String.format(
-            "The file at %s exceeds the client's max file size limit (%d)", fileUrl, maxSize));
+            Locale.ROOT,
+            "The file at %s exceeds the client's max file size limit (%d)",
+            fileUrl,
+            maxSize));
     this.fileUrl = fileUrl;
     this.maxSize = maxSize;
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileNotFoundException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileNotFoundException.java
@@ -15,10 +15,12 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 /** Thrown when a metadata resources was unexpectedly missing. */
 public class FileNotFoundException extends TufException {
 
   public FileNotFoundException(String fileName, String source) {
-    super(String.format("file (%s) was not found at source (%s).", fileName, source));
+    super(String.format(Locale.ROOT, "file (%s) was not found at source (%s).", fileName, source));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/HttpMetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/HttpMetaFetcher.java
@@ -27,6 +27,7 @@ import dev.sigstore.tuf.model.SignedTufMeta;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Optional;
 
 public class HttpMetaFetcher implements MetaFetcher {
@@ -64,7 +65,7 @@ public class HttpMetaFetcher implements MetaFetcher {
   public <T extends SignedTufMeta> Optional<MetaFetchResult<T>> getMeta(
       Role.Name role, Class<T> t, Integer maxSize)
       throws IOException, FileExceedsMaxLengthException {
-    String fileName = role.name().toLowerCase() + ".json";
+    String fileName = role.name().toLowerCase(Locale.ROOT) + ".json";
     return getMeta(fileName, t, maxSize);
   }
 
@@ -101,8 +102,11 @@ public class HttpMetaFetcher implements MetaFetcher {
     if (resp.getStatusCode() != 200) {
       throw new TufException(
           String.format(
+              Locale.ROOT,
               "Unexpected return from mirror(%s). Status code: %s, status message: %s",
-              mirror, resp.getStatusCode(), resp.getStatusMessage()));
+              mirror,
+              resp.getStatusCode(),
+              resp.getStatusMessage()));
     }
     byte[] roleBytes = resp.getContent().readNBytes(maxLength);
     if (roleBytes.length == maxLength && resp.getContent().read() != -1) {

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/InvalidHashesException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/InvalidHashesException.java
@@ -16,6 +16,7 @@
 package dev.sigstore.tuf;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /** Thrown when a hash check fails for a given resource. */
@@ -34,8 +35,11 @@ public class InvalidHashesException extends TufException {
     @Override
     public String toString() {
       return String.format(
+          Locale.ROOT,
           "algorithm: %s, expected hash: %s, computed hash: %s",
-          algorithm, expectedHash, computedHash);
+          algorithm,
+          expectedHash,
+          computedHash);
     }
   }
 
@@ -47,8 +51,10 @@ public class InvalidHashesException extends TufException {
   InvalidHashesException(String resourceName, InvalidHash... invalidHashes) {
     super(
         String.format(
+            Locale.ROOT,
             "The hashes for %s did not match expectations:\n%s",
-            resourceName, invalidHashesToString(invalidHashes)));
+            resourceName,
+            invalidHashesToString(invalidHashes)));
   }
 
   private static String invalidHashesToString(InvalidHash... invalidHashes) {

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/RoleExpiredException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/RoleExpiredException.java
@@ -16,6 +16,7 @@
 package dev.sigstore.tuf;
 
 import java.time.ZonedDateTime;
+import java.util.Locale;
 
 /**
  * Thrown when the local trusted role is expired and no valid un-expired new role is found on the
@@ -30,9 +31,12 @@ public class RoleExpiredException extends TufException {
       String mirrorUrl, ZonedDateTime updateTime, ZonedDateTime roleExpirationTime) {
     super(
         String.format(
+            Locale.ROOT,
             "Trusted metadata is expired but no new versions are available at the "
                 + "mirror URL:(%s)\n update start time: %tc\n expired time: %tc)",
-            mirrorUrl, updateTime, roleExpirationTime));
+            mirrorUrl,
+            updateTime,
+            roleExpirationTime));
     this.mirrorUrl = mirrorUrl;
     this.updateTime = updateTime;
     this.roleExpirationTime = roleExpirationTime;

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/RollbackVersionException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/RollbackVersionException.java
@@ -15,6 +15,8 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 /** Thrown when the version of the latest downloaded role does not match the expectation. */
 public class RollbackVersionException extends TufException {
   private int currentVersion;
@@ -23,7 +25,10 @@ public class RollbackVersionException extends TufException {
   public RollbackVersionException(int currentVersion, int foundVersion) {
     super(
         String.format(
-            "Expected version %d or higher but found version %d", currentVersion, foundVersion));
+            Locale.ROOT,
+            "Expected version %d or higher but found version %d",
+            currentVersion,
+            foundVersion));
     this.currentVersion = currentVersion;
     this.foundVersion = foundVersion;
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SignatureVerificationException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SignatureVerificationException.java
@@ -15,6 +15,8 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 /** Thrown when the metadata has not been signed by enough of the allowed keys. */
 public class SignatureVerificationException extends TufException {
   private final int requiredSignatures, verifiedSignatures;
@@ -22,8 +24,10 @@ public class SignatureVerificationException extends TufException {
   public SignatureVerificationException(int requiredSignatures, int verifiedSignatures) {
     super(
         String.format(
+            Locale.ROOT,
             "The role has not been signed by enough keys. [Theshold: %d, Actual: %d]",
-            requiredSignatures, verifiedSignatures));
+            requiredSignatures,
+            verifiedSignatures));
     this.requiredSignatures = requiredSignatures;
     this.verifiedSignatures = verifiedSignatures;
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SnapshotTargetMissingException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SnapshotTargetMissingException.java
@@ -15,8 +15,14 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 public class SnapshotTargetMissingException extends TufException {
   public SnapshotTargetMissingException(String targetName) {
-    super(String.format("Snapshot target [%s] was missing from updated snapshot.json", targetName));
+    super(
+        String.format(
+            Locale.ROOT,
+            "Snapshot target [%s] was missing from updated snapshot.json",
+            targetName));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SnapshotTargetVersionException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SnapshotTargetVersionException.java
@@ -15,11 +15,16 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 public class SnapshotTargetVersionException extends TufException {
   public SnapshotTargetVersionException(String targetName, int invalidVersion, int currentVersion) {
     super(
         String.format(
+            Locale.ROOT,
             "The updated target [%s] version [%d] is not equal to or greater than the current version [%d].",
-            targetName, invalidVersion, currentVersion));
+            targetName,
+            invalidVersion,
+            currentVersion));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SnapshotVersionMismatchException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SnapshotVersionMismatchException.java
@@ -15,11 +15,15 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 public class SnapshotVersionMismatchException extends TufException {
   public SnapshotVersionMismatchException(int expectedVersion, int actualVersion) {
     super(
         String.format(
+            Locale.ROOT,
             "Snapshot version (%d) did not match Timestamp resource (%d)",
-            actualVersion, expectedVersion));
+            actualVersion,
+            expectedVersion));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TargetMetadataMissingException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TargetMetadataMissingException.java
@@ -15,8 +15,10 @@
  */
 package dev.sigstore.tuf;
 
+import java.util.Locale;
+
 public class TargetMetadataMissingException extends TufException {
   public TargetMetadataMissingException(String targetName) {
-    super(String.format("The target (%s) has no metadata", targetName));
+    super(String.format(Locale.ROOT, "The target (%s) has no metadata", targetName));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -33,7 +33,12 @@ import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Clock;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import org.bouncycastle.util.encoders.Hex;
 
 /**
@@ -173,7 +178,8 @@ public class Updater {
         trustedRoot.getSignedMeta().getKeys(),
         trustedRoot
             .getSignedMeta()
-            .getRole(Role.Name.valueOf(delegate.getSignedMeta().getType().toUpperCase())),
+            .getRole(
+                Role.Name.valueOf(delegate.getSignedMeta().getType().toUpperCase(Locale.ROOT))),
         delegate.getCanonicalSignedBytes());
   }
 
@@ -337,7 +343,9 @@ public class Updater {
     if (expectedSha256 == null && expectedSha512 == null) {
       throw new IllegalArgumentException(
           String.format(
-              "hashes parameter for %s must contain at least one of sha512 or sha256.", name));
+              Locale.ROOT,
+              "hashes parameter for %s must contain at least one of sha512 or sha256.",
+              name));
     }
     String computedSha512 = Hashing.sha512().hashBytes(data).toString();
     if (expectedSha512 != null && !computedSha512.equals(expectedSha512)) {

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Role.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Role.java
@@ -16,6 +16,7 @@
 package dev.sigstore.tuf.model;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * TUF uses roles to define the set of actions a party can perform. The concept of roles allows TUF
@@ -34,7 +35,7 @@ public interface Role {
 
     @Override
     public String toString() {
-      return super.toString().toLowerCase();
+      return super.toString().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/sigstore-java/src/test/java/dev/sigstore/json/GsonSupplierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/json/GsonSupplierTest.java
@@ -19,6 +19,7 @@ import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -27,12 +28,13 @@ public class GsonSupplierTest {
 
   @Test
   public void testWrite() {
-    Assertions.assertEquals("\"YWJjZA==\"", gson.toJson("abcd".getBytes()));
+    Assertions.assertEquals("\"YWJjZA==\"", gson.toJson("abcd".getBytes(StandardCharsets.UTF_8)));
   }
 
   @Test
   public void testRead() {
-    Assertions.assertArrayEquals("abcd".getBytes(), gson.fromJson("\"YWJjZA==\"", byte[].class));
+    Assertions.assertArrayEquals(
+        "abcd".getBytes(StandardCharsets.UTF_8), gson.fromJson("\"YWJjZA==\"", byte[].class));
     Assertions.assertArrayEquals(new byte[] {}, gson.fromJson("\"\"", byte[].class));
     Assertions.assertArrayEquals(new byte[] {}, gson.fromJson("null", byte[].class));
   }

--- a/sigstore-java/src/test/java/dev/sigstore/testing/CertGenerator.java
+++ b/sigstore-java/src/test/java/dev/sigstore/testing/CertGenerator.java
@@ -26,6 +26,8 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
@@ -63,7 +65,7 @@ public class CertGenerator {
 
     // create a short lived cert
     Date startDate = new Date(System.currentTimeMillis());
-    var calendar = Calendar.getInstance();
+    var calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
     calendar.setTime(startDate);
     calendar.add(Calendar.MINUTE, 20);
     var endDate = calendar.getTime();

--- a/sigstore-java/src/test/java/dev/sigstore/testing/FulcioWrapper.java
+++ b/sigstore-java/src/test/java/dev/sigstore/testing/FulcioWrapper.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import org.junit.jupiter.api.extension.*;
 
 /**
@@ -48,8 +49,10 @@ public class FulcioWrapper implements BeforeEachCallback, AfterEachCallback, Par
     Files.writeString(
         fulcioConfig,
         String.format(
+            Locale.ROOT,
             "{\"OIDCIssuers\":{ \"%s\": { \"IssuerURL\": \"%s\", \"ClientID\": \"sigstore\", \"Type\": \"email\"}}}",
-            issuer, issuer));
+            issuer,
+            issuer));
     return fulcioConfig;
   }
 


### PR DESCRIPTION
#### Summary

This fixes surprises in TR_tr locale which has "dotless i".
In case you wonder, here's an issue in OpenRewrite for automatic rewrite of the locale-dependent methods:
* https://github.com/openrewrite/rewrite/issues/1728

#### Release Note

NONE

#### Documentation

NONE