### PR TITLE
Verify required fields in Sigstore Bundle

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleFactoryInternal.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleFactoryInternal.java
@@ -16,6 +16,7 @@
 package dev.sigstore.bundle;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.KeylessSigningResult;
 import dev.sigstore.proto.bundle.v1.Bundle;
 import dev.sigstore.proto.bundle.v1.VerificationMaterial;
@@ -34,6 +35,8 @@ import java.util.stream.Collectors;
  *     specifications</a>
  */
 class BundleFactoryInternal {
+  static final JsonFormat.Printer JSON_PRINTER = JsonFormat.printer();
+
   /**
    * Generates Sigstore Bundle Builder from {@link KeylessSigningResult}. This might be useful in
    * case you want to add additional information to the bundle.
@@ -50,7 +53,8 @@ class BundleFactoryInternal {
                 .setMessageDigest(
                     HashOutput.newBuilder()
                         .setAlgorithm(HashAlgorithm.SHA2_256)
-                        .setDigest(ByteString.copyFrom(signingResult.getDigest()))));
+                        .setDigest(ByteString.copyFrom(signingResult.getDigest())))
+                .setSignature(ByteString.copyFrom(signingResult.getSignature())));
   }
 
   private static VerificationMaterial.Builder buildVerificationMaterial(

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleVerifier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.bundle;
+
+import dev.sigstore.proto.bundle.v1.Bundle;
+import java.util.List;
+
+/**
+ * Verifies if Sigstore Bundle is valid.
+ *
+ * @see <a href="https://github.com/sigstore/protobuf-specs">Sigstore Bundle Protobuf
+ *     specifications</a>
+ */
+public class BundleVerifier {
+  /**
+   * Verify if all required fields are initialized in the input protobuf message.
+   *
+   * @param bundleJson message to verify
+   * @return list of all the missing fields
+   */
+  public static List<String> findMissingFields(String bundleJson) {
+    Bundle.Builder bundle = BundleVerifierInternal.parseSigstoreBundle(bundleJson);
+    return BundleVerifierInternal.findMissingFields(bundle);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleVerifierInternal.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleVerifierInternal.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.bundle;
+
+import com.google.api.FieldBehavior;
+import com.google.api.FieldBehaviorProto;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.proto.bundle.v1.Bundle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Implements Sigstore Bundle verification. */
+public class BundleVerifierInternal {
+  static final JsonFormat.Parser JSON_PARSER = JsonFormat.parser();
+
+  /**
+   * Parses Sigstore Bundle JSON into protobuf.
+   *
+   * @param bundleJson input JSON
+   * @return parsed bundle
+   * @throws IllegalArgumentException if the JSON is invalid
+   */
+  static Bundle.Builder parseSigstoreBundle(String bundleJson) {
+    var bundle = Bundle.newBuilder();
+    try {
+      JSON_PARSER.merge(bundleJson, bundle);
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalArgumentException("Unable to parse Sigstore Bundle " + bundleJson, e);
+    }
+    return bundle;
+  }
+
+  /**
+   * Finds all the missing fields in the given protobuf message.
+   *
+   * @param message input message
+   * @return list of all the missing fields, or empty list if there are none
+   */
+  static List<String> findMissingFields(MessageOrBuilder message) {
+    final List<java.lang.String> missing = new ArrayList<>();
+    findMissingFields(message, "", missing);
+    return missing;
+  }
+
+  private static void findMissingFields(
+      MessageOrBuilder message, String prefix, List<String> missing) {
+    // Get missing fields of the message itself
+    for (Descriptors.FieldDescriptor field : message.getDescriptorForType().getFields()) {
+      if (!isRequired(field)) {
+        continue;
+      }
+      // The parts of a "oneof {...}" are not required on their own
+      if (field.getContainingOneof() != null) {
+        continue;
+      }
+      // The field was required, so verify if it contains data
+      if (field.isRepeated()) {
+        if (message.getRepeatedFieldCount(field) != 0) {
+          // Repeated field has values => OK
+          continue;
+        }
+      } else if (message.hasField(field)) {
+        // Field is present => OK
+        continue;
+      }
+      // Field is missing
+      missing.add(prefix + field.getName());
+    }
+    // Verify oneof fields. They are required if any of the fields in the oneof is required.
+    for (Descriptors.OneofDescriptor oneof : message.getDescriptorForType().getRealOneofs()) {
+      if (!message.hasOneof(oneof)
+          && oneof.getFields().stream().anyMatch(BundleVerifierInternal::isRequired)) {
+        missing.add(prefix + oneof.getName());
+      }
+    }
+    // Recurse into each set message field
+    // getAllFields returns only present fields
+    for (final Map.Entry<Descriptors.FieldDescriptor, Object> entry :
+        message.getAllFields().entrySet()) {
+      Descriptors.FieldDescriptor field = entry.getKey();
+      Object value = entry.getValue();
+
+      if (field.getJavaType() != Descriptors.FieldDescriptor.JavaType.MESSAGE) {
+        continue;
+      }
+      if (!field.isRepeated()) {
+        findMissingFields((MessageOrBuilder) value, subMessagePrefix(prefix, field, -1), missing);
+      } else {
+        int i = 0;
+        //noinspection unchecked
+        for (final MessageOrBuilder element : (List<MessageOrBuilder>) value) {
+          findMissingFields(element, subMessagePrefix(prefix, field, i++), missing);
+        }
+      }
+    }
+  }
+
+  private static String subMessagePrefix(
+      String prefix, Descriptors.FieldDescriptor field, int index) {
+    StringBuilder result = new StringBuilder(prefix);
+    if (field.isExtension()) {
+      result.append('(').append(field.getFullName()).append(')');
+    } else {
+      result.append(field.getName());
+    }
+    if (index != -1) {
+      result.append('[').append(index).append(']');
+    }
+    result.append('.');
+    return result.toString();
+  }
+
+  static boolean isRequired(Descriptors.FieldDescriptor field) {
+    return field.isRequired()
+        || field
+            .toProto()
+            .getOptions()
+            .getExtension(FieldBehaviorProto.fieldBehavior)
+            .contains(FieldBehavior.REQUIRED);
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/bundle/AllRequiredFieldsInBundleTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/bundle/AllRequiredFieldsInBundleTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.bundle;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.MessageOrBuilder;
+import dev.sigstore.proto.bundle.v1.Bundle;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Collect all the required fields reachable from Bundle. It helps to catch if new required fields
+ * are added to the Bundle.
+ */
+public class AllRequiredFieldsInBundleTest {
+  static class MessageAndFields {
+    private final Descriptors.Descriptor descriptor;
+    private final List<Descriptors.GenericDescriptor> fields;
+
+    public MessageAndFields(
+        Descriptors.Descriptor descriptor, List<Descriptors.GenericDescriptor> fields) {
+      this.descriptor = descriptor;
+      this.fields = fields;
+    }
+
+    @Override
+    public String toString() {
+      return descriptor.getFullName()
+          + "\n"
+          + fields.stream()
+              .map(Descriptors.GenericDescriptor::getName)
+              .collect(Collectors.joining("\n    ", "    ", ""));
+    }
+  }
+
+  @Test
+  void allRequiredFieldsInBundle() {
+    var messages = new LinkedHashMap<Descriptors.Descriptor, MessageAndFields>();
+    var seen = new HashSet<Descriptors.Descriptor>();
+    collectRequiredFields(Bundle.getDescriptor(), messages, seen);
+    String str =
+        messages.values().stream().map(Object::toString).collect(Collectors.joining("\n\n"));
+
+    Assertions.assertEquals(
+        "dev.sigstore.common.v1.X509Certificate\n"
+            + "    raw_bytes\n"
+            + "\n"
+            + "dev.sigstore.common.v1.LogId\n"
+            + "    key_id\n"
+            + "\n"
+            + "dev.sigstore.common.v1.RFC3161SignedTimestamp\n"
+            + "    signed_timestamp\n"
+            + "\n"
+            + "dev.sigstore.bundle.v1.VerificationMaterial\n"
+            + "    content\n"
+            + "\n"
+            + "dev.sigstore.common.v1.MessageSignature\n"
+            + "    message_digest\n"
+            + "    signature\n"
+            + "\n"
+            + "dev.sigstore.bundle.v1.Bundle\n"
+            + "    verification_material\n"
+            + "    content",
+        str,
+        "List of all the required fields reachable from Bundle. "
+            + "If you see a test failure here (e.g. new required field is added), then "
+            + " it you might probably need to account the changes in BundleFactory");
+  }
+
+  /**
+   * Fetch all the messages that have required fields. It will return all the messages reachable
+   * from the given root.
+   *
+   * <p>Note: the implementation resembles {@link
+   * BundleVerifierInternal#findMissingFields(MessageOrBuilder)}, however, the difference is that
+   * this method finds all the required fields of all the messages, while {@link
+   * BundleVerifierInternal#findMissingFields(MessageOrBuilder)} verifies an actual given message
+   *
+   * @see BundleVerifierInternal#findMissingFields(MessageOrBuilder)
+   */
+  private void collectRequiredFields(
+      Descriptors.Descriptor descriptor,
+      Map<Descriptors.Descriptor, MessageAndFields> messages,
+      Set<Descriptors.Descriptor> seen) {
+    seen.add(descriptor);
+    var fields = new ArrayList<Descriptors.GenericDescriptor>();
+    for (Descriptors.FieldDescriptor field : descriptor.getFields()) {
+      if (field.getJavaType() == Descriptors.FieldDescriptor.JavaType.MESSAGE) {
+        // Drill down into the message
+        var messageType = field.getMessageType();
+        if (!seen.contains(messageType)) {
+          collectRequiredFields(messageType, messages, seen);
+        }
+      }
+      if (!BundleVerifierInternal.isRequired(field)) {
+        continue;
+      }
+      if (field.getContainingOneof() == null) {
+        // Remember the field is required
+        fields.add(field);
+      }
+    }
+    for (Descriptors.OneofDescriptor oneof : descriptor.getRealOneofs()) {
+      if (oneof.getFields().stream().anyMatch(BundleVerifierInternal::isRequired)) {
+        fields.add(oneof);
+      }
+    }
+    if (!fields.isEmpty()) {
+      messages.put(descriptor, new MessageAndFields(descriptor, fields));
+    }
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/bundle/BundleVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/bundle/BundleVerifierTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.bundle;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.MessageOrBuilder;
+import dev.sigstore.proto.bundle.v1.Bundle;
+import dev.sigstore.proto.common.v1.LogId;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BundleVerifierTest {
+  static Iterable<Arguments> findMissingFields_data() {
+    return List.of(
+        arguments("LogId.newBuilder()", LogId.newBuilder(), List.of("key_id")),
+        arguments(
+            "LogId.newBuilder().setKeyId(empty)",
+            LogId.newBuilder().setKeyId(ByteString.EMPTY),
+            List.of("key_id")),
+        arguments(
+            "LogId.newBuilder().setKeyId(\"cafe\")",
+            LogId.newBuilder().setKeyId(ByteString.fromHex("cafe")),
+            List.of()),
+        arguments(
+            "Sigstore Bundle", Bundle.newBuilder(), List.of("verification_material", "content")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("findMissingFields_data")
+  void findMissingFields(String name, MessageOrBuilder message, List<String> missingFields) {
+    Assertions.assertThat(BundleVerifierInternal.findMissingFields(message))
+        .describedAs(name)
+        .isEqualTo(missingFields);
+  }
+}


### PR DESCRIPTION
#### Summary

Previously, message_signature.signature was missing, and there was no check to capture that.

The key non-test code here is `setSignature(ByteString.copyFrom(signingResult.getSignature()))` in `BundleFactoryInternal`.

#### Release Note

NONE

#### Documentation

NONE