### PR TITLE
Fetch Fulcio and Rekor certificates from TUF store

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/trust/ResourceBasedTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trust/ResourceBasedTufStore.java
@@ -1,0 +1,15 @@
+package dev.sigstore.trust;
+
+import dev.sigstore.tuf.MutableTufStore;
+
+/**
+ * Loads TUF data from classpath resources.
+ * TODO: it probably needs to verify the checksum of the loaded root.json.
+ */
+public class ResourceBasedTufStore implements MutableTufStore {
+  private final String prefix;
+
+  public ResourceBasedTufStore(String prefix) {
+    this.prefix = prefix;
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trust/TufBasedVerificationMaterial.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trust/TufBasedVerificationMaterial.java
@@ -1,0 +1,32 @@
+package dev.sigstore.trust;
+
+import dev.sigstore.tuf.MutableTufStore;
+import dev.sigstore.tuf.TufStore;
+import java.util.List;
+
+/**
+ * Extracts Fulcio, and Rekor certificates out of Sigstore TUF.
+ * It will replace {@link dev.sigstore.VerificationMaterial} in the future.
+ */
+public class TufBasedVerificationMaterial implements VerificationMaterial {
+  private final TufStore tufStore;
+
+  public TufBasedVerificationMaterial(TufStore tufStore) {
+    this.tufStore = tufStore;
+  }
+
+  @Override
+  public byte[] fulcioCert() {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public List<byte[]> ctfePublicKeys() {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
+  public byte[] rekorPublicKey() {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trust/UpdateableTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trust/UpdateableTufStore.java
@@ -1,0 +1,14 @@
+package dev.sigstore.trust;
+
+import dev.sigstore.tuf.MutableTufStore;
+
+/**
+ * Tuf
+ */
+public class InMemoryTufStore implements MutableTufStore {
+  private final MutableTufStore baseStore;
+
+  public UpdateableTufStore(MutableTufStore baseStore) {
+    this.baseStore = baseStore;
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trust/VerificationMaterial.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trust/VerificationMaterial.java
@@ -1,0 +1,9 @@
+package dev.sigstore.trust;
+
+import java.util.List;
+
+public interface VerificationMaterial {
+  byte[] fulcioCert();
+  List<byte[]> ctfePublicKeys();
+  byte[] rekorPublicKey();
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 /** Uses a local file system directory to store the trusted TUF metadata. */
-public class FileSystemTufStore implements TufLocalStore {
+public class FileSystemTufStore implements MutableTufStore {
 
   private static final String ROOT_FILE_NAME = "root.json";
   private static final String SNAPSHOT_FILE_NAME = "snapshot.json";
@@ -42,7 +42,7 @@ public class FileSystemTufStore implements TufLocalStore {
     this.targetsCache = targetsCache;
   }
 
-  public static TufLocalStore newFileSystemStore(Path repoBaseDir) throws IOException {
+  public static MutableTufStore newFileSystemStore(Path repoBaseDir) throws IOException {
     if (!Files.isDirectory(repoBaseDir)) {
       throw new IllegalArgumentException(repoBaseDir + " must be a file system directory.");
     }
@@ -51,7 +51,7 @@ public class FileSystemTufStore implements TufLocalStore {
     return newFileSystemStore(repoBaseDir, defaultTargetsCache);
   }
 
-  static TufLocalStore newFileSystemStore(Path repoBaseDir, Path targetsCache) {
+  static MutableTufStore newFileSystemStore(Path repoBaseDir, Path targetsCache) {
     if (!Files.isDirectory(repoBaseDir)) {
       throw new IllegalArgumentException(repoBaseDir + " must be a file system directory.");
     }
@@ -97,11 +97,11 @@ public class FileSystemTufStore implements TufLocalStore {
   }
 
   @Override
-  public <T extends SignedTufMeta> void storeMeta(T timestamp) throws IOException {
+  public void storeMeta(SignedTufMeta<?> timestamp) throws IOException {
     storeRole(timestamp);
   }
 
-  <T extends SignedTufMeta> Optional<T> loadRole(Role.Name roleName, Class<T> tClass)
+  <T extends SignedTufMeta<?>> Optional<T> loadRole(Role.Name roleName, Class<T> tClass)
       throws IOException {
     Path roleFile = repoBaseDir.resolve(roleName + ".json");
     if (!roleFile.toFile().exists()) {
@@ -110,7 +110,7 @@ public class FileSystemTufStore implements TufLocalStore {
     return Optional.of(GSON.get().fromJson(Files.readString(roleFile), tClass));
   }
 
-  <T extends SignedTufMeta> void storeRole(T role) throws IOException {
+  <T extends SignedTufMeta<?>> void storeRole(T role) throws IOException {
     try (BufferedWriter fileWriter =
         Files.newBufferedWriter(repoBaseDir.resolve(role.getSignedMeta().getType() + ".json"))) {
       GSON.get().toJson(role, fileWriter);

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MutableTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MutableTufStore.java
@@ -17,33 +17,9 @@ package dev.sigstore.tuf;
 
 import dev.sigstore.tuf.model.*;
 import java.io.IOException;
-import java.util.Optional;
 
 /** Defines the set of actions needed to support a local repository of TUF metadata. */
-public interface TufLocalStore {
-
-  /**
-   * A generic string for identifying the local store in debug messages. A file system based
-   * implementation might return the path being used for storage, while an in-memory store may just
-   * return something like 'in-memory'.
-   */
-  String getIdentifier();
-
-  /**
-   * If the local store has a root that has been blessed safe either by the client or through update
-   * and verification, then this method returns it.
-   */
-  Optional<Root> loadTrustedRoot() throws IOException;
-
-  /** Return local trusted timestamp metadata if there is any. */
-  Optional<Timestamp> loadTimestamp() throws IOException;
-
-  /** Return the local trusted snapshot metadata if there is any. */
-  Optional<Snapshot> loadSnapshot() throws IOException;
-
-  /** Return the local trusted targets metadata if there is any. */
-  Optional<Targets> loadTargets() throws IOException;
-
+public interface MutableTufStore extends TufStore {
   /**
    * Writes a TUF target to the local target store.
    *
@@ -54,22 +30,12 @@ public interface TufLocalStore {
   void storeTargetFile(String targetName, byte[] targetContents) throws IOException;
 
   /**
-   * Reads a TUF target file from the local TUF store
-   *
-   * @param targetName the name of the target file to read (e.g. ctfe.pub)
-   * @return the content of the file as bytes
-   * @throws IOException if an error occurs
-   */
-  byte[] getTargetFile(String targetName) throws IOException;
-
-  /**
    * Generic method to store one of the {@link SignedTufMeta} resources in the local tuf store.
    *
    * @param meta the metadata to store
-   * @param <T> a subtype of {@link SignedTufMeta}
    * @throws IOException if writing the resource causes an IO error
    */
-  <T extends SignedTufMeta> void storeMeta(T meta) throws IOException;
+  void storeMeta(SignedTufMeta<?> meta) throws IOException;
 
   /**
    * Once you have ascertained that your root is trustworthy use this method to persist it to your

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TufStore.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import dev.sigstore.tuf.model.Root;
+import dev.sigstore.tuf.model.Snapshot;
+import dev.sigstore.tuf.model.Targets;
+import dev.sigstore.tuf.model.Timestamp;
+import java.io.IOException;
+import java.util.Optional;
+
+public interface TufStore {
+  /**
+   * A generic string for identifying the local store in debug messages. A file system based
+   * implementation might return the path being used for storage, while an in-memory store may just
+   * return something like 'in-memory'.
+   */
+  String getIdentifier();
+
+  /** Local store must have a root that has been blessed safe. */
+  Optional<Root> loadTrustedRoot() throws IOException;
+
+  /** Return local trusted timestamp metadata if there is any. */
+  Optional<Timestamp> loadTimestamp() throws IOException;
+
+  /** Return the local trusted snapshot metadata if there is any. */
+  Optional<Snapshot> loadSnapshot() throws IOException;
+
+  /** Return the local trusted targets metadata if there is any. */
+  Optional<Targets> loadTargets() throws IOException;
+
+  /**
+   * Reads a TUF target file from the local TUF store
+   *
+   * @param targetName the name of the target file to read (e.g. ctfe.pub)
+   * @return the content of the file as bytes
+   * @throws IOException if an error occurs
+   */
+  byte[] getTargetFile(String targetName) throws IOException;
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -58,18 +58,15 @@ public class Updater {
   private Verifiers.Supplier verifiers;
   private MetaFetcher fetcher;
   private ZonedDateTime updateStartTime;
-  private Path trustedRootPath;
   private MutableTufStore localStore;
 
   Updater(
       Clock clock,
       Verifiers.Supplier verifiers,
       MetaFetcher fetcher,
-      Path trustedRootPath,
       MutableTufStore localStore) {
     this.clock = clock;
     this.verifiers = verifiers;
-    this.trustedRootPath = trustedRootPath;
     this.localStore = localStore;
     this.fetcher = fetcher;
   }
@@ -100,13 +97,7 @@ public class Updater {
 
     // 5.3.2) load the trust metadata file (root.json), get version of root.json and the role
     // signature threshold value
-    Optional<Root> localRoot = localStore.loadTrustedRoot();
-    Root trustedRoot;
-    if (localRoot.isPresent()) {
-      trustedRoot = localRoot.get();
-    } else {
-      trustedRoot = GSON.get().fromJson(Files.readString(trustedRootPath), Root.class);
-    }
+    Root trustedRoot = localStore.loadTrustedRoot();
     int baseVersion = trustedRoot.getSignedMeta().getVersion();
     int nextVersion = baseVersion + 1;
     // keep these for verifying the last step. 5.3.11
@@ -466,7 +457,7 @@ public class Updater {
     }
 
     public Updater build() {
-      return new Updater(clock, verifiers, fetcher, trustedRootPath, localStore);
+      return new Updater(clock, verifiers, fetcher, localStore);
     }
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -59,14 +59,14 @@ public class Updater {
   private MetaFetcher fetcher;
   private ZonedDateTime updateStartTime;
   private Path trustedRootPath;
-  private TufLocalStore localStore;
+  private MutableTufStore localStore;
 
   Updater(
       Clock clock,
       Verifiers.Supplier verifiers,
       MetaFetcher fetcher,
       Path trustedRootPath,
-      TufLocalStore localStore) {
+      MutableTufStore localStore) {
     this.clock = clock;
     this.verifiers = verifiers;
     this.trustedRootPath = trustedRootPath;
@@ -428,7 +428,7 @@ public class Updater {
   }
 
   @VisibleForTesting
-  TufLocalStore getLocalStore() {
+  MutableTufStore getLocalStore() {
     return localStore;
   }
 
@@ -438,7 +438,7 @@ public class Updater {
 
     private MetaFetcher fetcher;
     private Path trustedRootPath;
-    private TufLocalStore localStore;
+    private MutableTufStore localStore;
 
     public Builder setClock(Clock clock) {
       this.clock = clock;
@@ -450,7 +450,7 @@ public class Updater {
       return this;
     }
 
-    public Builder setLocalStore(TufLocalStore store) {
+    public Builder setLocalStore(MutableTufStore store) {
       this.localStore = store;
       return this;
     }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
@@ -21,7 +21,7 @@ import org.immutables.value.Value;
 /** Signed envelope of the Timestamp metadata. */
 @Gson.TypeAdapters
 @Value.Immutable
-public interface Timestamp extends SignedTufMeta<TufMeta> {
+public interface Timestamp extends SignedTufMeta<TimestampMeta> {
 
   @Override
   @Gson.Named("signed")

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
@@ -29,22 +29,22 @@ class FileSystemTufStoreTest {
 
   @Test
   void newFileSystemStore_empty(@TempDir Path repoBase) throws IOException {
-    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    assertFalse(tufLocalStore.loadTrustedRoot().isPresent());
+    MutableTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    assertFalse(tufStore.loadTrustedRoot().isPresent());
   }
 
   @Test
   void newFileSystemStore_hasRepo(@TempDir Path repoBase) throws IOException {
     TestResources.setupRepoFiles(PROD_REPO, repoBase, "root.json");
-    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    assertTrue(tufLocalStore.loadTrustedRoot().isPresent());
+    MutableTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    assertTrue(tufStore.loadTrustedRoot().isPresent());
   }
 
   @Test
   void setTrustedRoot_noPrevious(@TempDir Path repoBase) throws IOException {
-    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    MutableTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertFalse(repoBase.resolve("root.json").toFile().exists());
-    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
+    tufStore.storeTrustedRoot(TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
     assertEquals(2, repoBase.toFile().list().length, "Expect 2: root.json plus the /targets dir.");
     assertTrue(repoBase.resolve("root.json").toFile().exists());
     assertTrue(repoBase.resolve("targets").toFile().isDirectory());
@@ -53,20 +53,20 @@ class FileSystemTufStoreTest {
   @Test
   void setTrustedRoot_backupPerformed(@TempDir Path repoBase) throws IOException {
     TestResources.setupRepoFiles(PROD_REPO, repoBase, "root.json");
-    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    int version = tufLocalStore.loadTrustedRoot().get().getSignedMeta().getVersion();
+    MutableTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    int version = tufStore.loadTrustedRoot().get().getSignedMeta().getVersion();
     assertFalse(repoBase.resolve(version + ".root.json").toFile().exists());
-    tufLocalStore.storeTrustedRoot(TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
+    tufStore.storeTrustedRoot(TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
     assertTrue(repoBase.resolve(version + ".root.json").toFile().exists());
   }
 
   @Test
   void clearMetaDueToKeyRotation(@TempDir Path repoBase) throws IOException {
     TestResources.setupRepoFiles(PROD_REPO, repoBase, "snapshot.json", "timestamp.json");
-    TufLocalStore tufLocalStore = FileSystemTufStore.newFileSystemStore(repoBase);
+    MutableTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertTrue(repoBase.resolve("snapshot.json").toFile().exists());
     assertTrue(repoBase.resolve("timestamp.json").toFile().exists());
-    tufLocalStore.clearMetaDueToKeyRotation();
+    tufStore.clearMetaDueToKeyRotation();
     assertFalse(repoBase.resolve("snapshot.json").toFile().exists());
     assertFalse(repoBase.resolve("timestamp.json").toFile().exists());
   }


### PR DESCRIPTION
#### Summary

The idea is:
1. replace current `VerificationMaterial` (see https://github.com/sigstore/sigstore-java/blob/5539b01a017b17c5243a080eb00c528b082a0074/sigstore-java/src/main/java/dev/sigstore/VerificationMaterial.java ) class with a TUF repository
2. and make TUF repository auto-updateable (e.g. if the root rotates during we sign)

It builds upon https://github.com/sigstore/sigstore-java/pull/325, so check the second commit in the PR.

It looks like we need to deprecate:
1. `dev.sigstore.VerificationMaterial`
2. `dev.sigstore.fulcio.client.FulcioVerifier#newFulcioVerifier(byte[] fulcioRoot, List<byte[]> ctfePublicKeys)`. I suggest replacing it with `newFulcioVerifier(TufBasedVerificationMaterial)`
3. `dev.sigstore.rekor.client.RekorVerifier#newRekorVerifier(byte[] rekorPublicKey)` -> `newRekorVerifier(TufBasedVerificationMaterial)`

#### Release Note

Support Fulcio, Rekor, CTFE certificate rotation via TUF.

#### Documentation

NONE