### PR TITLE
Fix reference to GitHub repo in release notes

### DIFF
--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -107,5 +107,5 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag=v0.1.15
         with:
           tag_name: v${{ github.event.inputs.release_version }}
-          body: See [CHANGELOG.md](https://github.com/$GITHUB_REPOSITORY/CHANGELOG.md) for more details.
+          body: "See [CHANGELOG.md](https://github.com/${{ env.GITHUB_REPOSITORY }}/CHANGELOG.md) for more details."
           files: ./release/*


### PR DESCRIPTION
As it was broken in [0.3.0](https://github.com/sigstore/sigstore-java/releases/tag/v0.3.0) - `https://github.com/$GITHUB_REPOSITORY/CHANGELOG.md`. Related to #332.

Btw, it should work, but the release workflow is not available from a fork.
