### PR TITLE
Add auto oidc selector

### DIFF
--- a/sigstore-conformance/src/main/java/dev/sigstore/conformance/Main.java
+++ b/sigstore-conformance/src/main/java/dev/sigstore/conformance/Main.java
@@ -19,7 +19,6 @@ import static dev.sigstore.encryption.certificates.Certificates.toPemString;
 
 import dev.sigstore.KeylessSigner;
 import dev.sigstore.KeylessVerifier;
-import dev.sigstore.oidc.client.GithubActionsOidcClient;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -102,11 +101,7 @@ public class Main {
   }
 
   private static void executeSign(SignArguments args) throws Exception {
-    final var signer =
-        KeylessSigner.builder()
-            .sigstorePublicDefaults()
-            .oidcClient(GithubActionsOidcClient.builder().build())
-            .build();
+    final var signer = KeylessSigner.builder().sigstorePublicDefaults().build();
     final var result = signer.signFile(args.artifact);
     Files.write(args.signature, result.getSignature());
     final var pemBytes = toPemString(result.getCertPath()).getBytes(StandardCharsets.UTF_8);

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/tasks/SigstoreSignFilesTask.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/tasks/SigstoreSignFilesTask.kt
@@ -65,6 +65,7 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
         passEnvironmentVariables.addAll(
             "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
             "ACTIONS_ID_TOKEN_REQUEST_URL",
+            "GITHUB_ACTIONS",
         )
     }
 

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/work/SignWorkAction.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/work/SignWorkAction.kt
@@ -19,6 +19,7 @@ package dev.sigstore.sign.work
 import dev.sigstore.KeylessSigner
 import dev.sigstore.bundle.BundleFactory
 import dev.sigstore.oidc.client.OidcClient
+import dev.sigstore.oidc.client.OidcClients
 import dev.sigstore.sign.OidcClientConfiguration
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -50,7 +51,7 @@ abstract class SignWorkAction : WorkAction<SignWorkParameters> {
         val signer = clients.computeIfAbsent(oidcClient.key()) {
             KeylessSigner.builder().apply {
                 sigstorePublicDefaults()
-                oidcClient(oidcClient.build() as OidcClient)
+                oidcClients(OidcClients.of(oidcClient.build() as OidcClient))
             }.build()
         }
 

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/GithubActionsOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/GithubActionsOidcClient.java
@@ -25,12 +25,17 @@ import dev.sigstore.http.HttpParams;
 import dev.sigstore.http.ImmutableHttpParams;
 import io.grpc.Internal;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * Obtain an oidc token from the github execution environment.
  * https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
  */
 public class GithubActionsOidcClient implements OidcClient {
+
+  private static final Logger log = Logger.getLogger(GithubActionsOidcClient.class.getName());
+
+  private static final String GITHUB_ACTIONS_KEY = "GITHUB_ACTIONS";
   private static final String REQUEST_TOKEN_KEY = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
   private static final String REQUEST_URL_KEY = "ACTIONS_ID_TOKEN_REQUEST_URL";
 
@@ -67,6 +72,16 @@ public class GithubActionsOidcClient implements OidcClient {
     public GithubActionsOidcClient build() {
       return new GithubActionsOidcClient(httpParams, audience);
     }
+  }
+
+  @Override
+  public boolean isEnabled() {
+    var githubActions = System.getenv(GITHUB_ACTIONS_KEY);
+    if (githubActions == null || githubActions.isEmpty()) {
+      log.fine("Github env not detected: skipping github actions oidc");
+      return false;
+    }
+    return true;
   }
 
   @Override

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/OidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/OidcClient.java
@@ -16,5 +16,14 @@
 package dev.sigstore.oidc.client;
 
 public interface OidcClient {
+
+  /**
+   * Determine if this client can be used in the current environment. For example, we can ignore
+   * Oidc Clients that are scoped to a specific CI environment
+   *
+   * @return true if we should use credentials from this client
+   */
+  boolean isEnabled();
+
   OidcToken getIDToken() throws OidcException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/OidcClients.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/OidcClients.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+import com.google.common.collect.ImmutableList;
+
+/** An ordered list of oidc clients to use when looking for credentials. */
+public class OidcClients {
+
+  public static final OidcClients DEFAULTS =
+      of(GithubActionsOidcClient.builder().build(), WebOidcClient.builder().build());
+
+  public static final OidcClients STAGING_DEFAULTS =
+      of(
+          GithubActionsOidcClient.builder().build(),
+          WebOidcClient.builder().setIssuer(WebOidcClient.STAGING_DEX_ISSUER).build());
+
+  private final ImmutableList<OidcClient> clients;
+
+  public static OidcClients of(OidcClient... clients) {
+    return new OidcClients(ImmutableList.copyOf(clients));
+  }
+
+  private OidcClients(ImmutableList<OidcClient> clients) {
+    this.clients = clients;
+  }
+
+  /**
+   * Attempts to obtain a token from the first enabled oidc provider and errors if a failure occurs,
+   * does not try other providers if the first provider fails.
+   *
+   * @return an oidc token
+   * @throws OidcException if token request fails or if no valid provider was found
+   */
+  public OidcToken getIDToken() throws OidcException {
+    for (var client : clients) {
+      if (client.isEnabled()) {
+        return client.getIDToken();
+      }
+    }
+    throw new OidcException("Could not find an oidc provider");
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
@@ -113,6 +113,15 @@ public class WebOidcClient implements OidcClient {
   }
 
   /**
+   * This provider is always enabled by default, however it should be lower priority over other
+   * providers which obtain ambient credentials.
+   */
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  /**
    * Get an id token from the oidc provider with openid and email scopes
    *
    * @return an openid token with additional email scopes

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -17,7 +17,6 @@ package dev.sigstore;
 
 import com.google.common.hash.Hashing;
 import dev.sigstore.encryption.certificates.Certificates;
-import dev.sigstore.oidc.client.GithubActionsOidcClient;
 import dev.sigstore.rekor.client.RekorTypeException;
 import dev.sigstore.rekor.client.RekorTypes;
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists;
@@ -39,7 +38,6 @@ public class KeylessTest {
   @TempDir public static Path testRoot;
 
   public static List<byte[]> artifactDigests;
-  public static List<Path> artifacts;
 
   @BeforeAll
   public static void setupArtifact() throws IOException {
@@ -59,7 +57,7 @@ public class KeylessTest {
   }
 
   @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.MANUAL)
+  @EnabledIfOidcExists(provider = OidcProviderType.ANY)
   public void sign_production() throws Exception {
     var signer = KeylessSigner.builder().sigstorePublicDefaults().build();
     var results = signer.sign(artifactDigests);
@@ -74,45 +72,9 @@ public class KeylessTest {
   }
 
   @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.MANUAL)
+  @EnabledIfOidcExists(provider = OidcProviderType.ANY)
   public void sign_staging() throws Exception {
     var signer = KeylessSigner.builder().sigstoreStagingDefaults().build();
-    var results = signer.sign(artifactDigests);
-    verifySigningResult(results);
-
-    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
-    for (var result : results) {
-      verifier.verifyOnline(
-          result.getDigest(), Certificates.toPemBytes(result.getCertPath()), result.getSignature());
-    }
-  }
-
-  @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.GITHUB)
-  public void sign_productionWithGithubOidc() throws Exception {
-    var signer =
-        KeylessSigner.builder()
-            .sigstorePublicDefaults()
-            .oidcClient(GithubActionsOidcClient.builder().build())
-            .build();
-    var results = signer.sign(artifactDigests);
-    verifySigningResult(results);
-
-    var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-    for (var result : results) {
-      verifier.verifyOnline(
-          result.getDigest(), Certificates.toPemBytes(result.getCertPath()), result.getSignature());
-    }
-  }
-
-  @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.GITHUB)
-  public void sign_stagingWithGithubOidc() throws Exception {
-    var signer =
-        KeylessSigner.builder()
-            .sigstoreStagingDefaults()
-            .oidcClient(GithubActionsOidcClient.builder().build())
-            .build();
     var results = signer.sign(artifactDigests);
     verifySigningResult(results);
 


### PR DESCRIPTION
Currently auto selects github oidc or web based processing. But should allow us to add in more token providers with stronger ambient credential detection.

Signed-off-by: Appu Goundan <appu@google.com>

We need to add gcp (and in the future buildkite) for parity with the other clients.