### PR TITLE
test: distinguish between locally installed 0.3 and remote 0.3 sigstore-java better

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=768m
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 group=dev.sigstore
-version=0.3.0
+version=0.4.0

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -39,7 +39,7 @@ abstract class SigstoreSignExtension(private val project: Project) {
     abstract val sigstoreJavaVersion : Property<String>
 
     init {
-        sigstoreJavaVersion.convention("0.3.0")
+        sigstoreJavaVersion.convention("0.4.0")
         (this as ExtensionAware).extensions.create<OidcClientExtension>(
             "oidcClient",
             project.objects,

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/work/SignWorkAction.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/work/SignWorkAction.kt
@@ -19,7 +19,6 @@ package dev.sigstore.sign.work
 import dev.sigstore.KeylessSigner
 import dev.sigstore.bundle.BundleFactory
 import dev.sigstore.oidc.client.OidcClient
-import dev.sigstore.oidc.client.OidcClients
 import dev.sigstore.sign.OidcClientConfiguration
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -51,7 +50,8 @@ abstract class SignWorkAction : WorkAction<SignWorkParameters> {
         val signer = clients.computeIfAbsent(oidcClient.key()) {
             KeylessSigner.builder().apply {
                 sigstorePublicDefaults()
-                oidcClients(OidcClients.of(oidcClient.build() as OidcClient))
+                @Suppress("DEPRECATION")
+                oidcClient(oidcClient.build() as OidcClient)
             }.build()
         }
 

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -21,11 +21,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.InlineMe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.encryption.signers.Signer;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.fulcio.client.*;
+import dev.sigstore.oidc.client.OidcClient;
 import dev.sigstore.oidc.client.OidcClients;
 import dev.sigstore.oidc.client.OidcException;
 import dev.sigstore.oidc.client.OidcToken;
@@ -138,6 +140,15 @@ public class KeylessSigner implements AutoCloseable {
       this.rekorClient = rekorClient;
       this.rekorVerifier = rekorVerifier;
       return this;
+    }
+
+    @CanIgnoreReturnValue
+    @Deprecated
+    @InlineMe(
+        replacement = "this.oidcClients(OidcClients.of(oidcClient))",
+        imports = "dev.sigstore.oidc.client.OidcClients")
+    public final Builder oidcClient(OidcClient oidcClient) {
+      return oidcClients(OidcClients.of(oidcClient));
     }
 
     @CanIgnoreReturnValue

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
@@ -42,7 +42,7 @@ open class BaseGradleTest {
         val EXTRA_LOCAL_REPOS  = System.getProperty("sigstore.test.local.maven.repo").split(File.pathSeparatorChar)
 
         val SIGSTORE_JAVA_CURRENT_VERSION =
-            TestedSigstoreJava.Version(
+            TestedSigstoreJava.LocallyBuiltVersion(
                 System.getProperty("sigstore.test.current.version")
             )
 
@@ -96,7 +96,11 @@ open class BaseGradleTest {
     protected fun declareRepositories(sigstoreJava: TestedSigstoreJava) =
         """
         repositories {${
-            if (sigstoreJava == SIGSTORE_JAVA_CURRENT_VERSION || sigstoreJava is TestedSigstoreJava.Default) {
+            if (sigstoreJava is TestedSigstoreJava.Version) {
+                ""
+            } else {
+                // We assume that the plugin defaults to the same version of the library, so we test both
+                // Default and LocallyBuiltVersion from locally staged repo
                 EXTRA_LOCAL_REPOS.joinToString("\n") {
                     """
 
@@ -107,8 +111,6 @@ open class BaseGradleTest {
                 }
                 """.trimIndent().prependIndent("            ")
                 }
-            } else {
-                ""
             }
         }
             mavenCentral()
@@ -122,6 +124,8 @@ open class BaseGradleTest {
                 when (sigstoreJava) {
                     TestedSigstoreJava.Default -> ""
                     is TestedSigstoreJava.Version ->
+                        "sigstoreClient(\"dev.sigstore:sigstore-java:${sigstoreJava.version}\")"
+                    is TestedSigstoreJava.LocallyBuiltVersion ->
                         "sigstoreClient(\"dev.sigstore:sigstore-java:${sigstoreJava.version}\")"
                 }
             }

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedSigstoreJava.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedSigstoreJava.kt
@@ -28,9 +28,16 @@ sealed class TestedSigstoreJava {
     }
 
     /**
-     * Configures sigstore-java version for testing with Sigstore Gradle plugin.
+     * Configures taken from external repository sigstore-java version for testing with Sigstore Gradle plugin.
      */
     data class Version(
+        val version: String,
+    ): TestedSigstoreJava()
+
+    /**
+     * Configures locally-built sigstore-java version for testing with Sigstore Gradle plugin.
+     */
+    data class LocallyBuiltVersion(
         val version: String,
     ): TestedSigstoreJava()
 }


### PR DESCRIPTION
#### Summary

Previously the test was comparing "requested version with project version" to tell if it needs to fetch sigstore-java from Central.
Now there is `LocallyBuiltVersion` class so the test can distinguish better, especially when project version in `gradle.properties` was not updated after release.

#### Release Note

NONE

#### Documentation

NONE