### PR TITLE
chore: reduce Renovate frequency, add labels for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:base"
   ],
-  "schedule": ["every weekend"],
+  "labels": ["dependencies"],
+  "schedule": ["every 3 week"],
   "packageRules": [
     {
       "matchPackagePrefixes": ["org.immutables"],


### PR DESCRIPTION
#### Summary

We don't release often enough, so there's no much sense in updating the dependencies often.

#### Release Note

NONE

#### Documentation

NONE