### PR TITLE
Add initial BYOB-based SLSA-generator

### DIFF
--- a/.github/workflows/byob-slsa.yaml
+++ b/.github/workflows/byob-slsa.yaml
@@ -1,0 +1,28 @@
+# This builds a SLSA provenance statement based on BYOB.
+# For now it is under heavy development and is not yes suited for releases.
+---
+name: SLSA Provenance
+on:
+  - workflow_dispatch
+
+permissions: read-all
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  ISSUE_REPOSITORY: ${{ github.repository }}
+jobs:
+  usetrw:
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
+      packages: write
+    uses: AdamKorcz/java-slsa-generator/.github/workflows/gradle-trw.yml@main
+    with:
+      rekor-log-public: true
+      artifact-list: |
+        ./sigstore-java/build/local-maven-repo/dev/sigstore/sigstore-java/GRADLE_VERSION/sigstore-java-GRADLE_VERSION.module,
+        ./sigstore-java/build/libs/sigstore-java-GRADLE_VERSION.jar,
+        ./sigstore-java/build/local-maven-repo/dev/sigstore/sigstore-java/GRADLE_VERSION/sigstore-java-GRADLE_VERSION.pom,
+        ./sigstore-java/build/local-maven-repo/dev/sigstore/sigstore-java/GRADLE_VERSION/sigstore-java-GRADLE_VERSION-sources.jar,
+        ./sigstore-java/build/libs/sigstore-java-GRADLE_VERSION-javadoc.jar

--- a/.github/workflows/byob-slsa.yaml
+++ b/.github/workflows/byob-slsa.yaml
@@ -1,5 +1,5 @@
 # This builds a SLSA provenance statement based on BYOB.
-# For now it is under heavy development and is not yes suited for releases.
+# For now it is under heavy development and is not yet suited for releases.
 ---
 name: SLSA Provenance
 on:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds the initial workflow for the Bring-Your-Own-Builder-based SLSA generator. 

Currently the builder is hosted on my Github user, because the builder is under development. I am uploading it here to get it integrated early in the development process of the gradle builder. The BYOB-based generator should not disrupt any other workflows since it it needs to be manually triggered to run. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->