### PR TITLE
Add parsing of bundle to KeylessSigningResult

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleFactory.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleFactory.java
@@ -18,6 +18,7 @@ package dev.sigstore.bundle;
 import com.google.protobuf.InvalidProtocolBufferException;
 import dev.sigstore.KeylessSigningResult;
 import dev.sigstore.proto.bundle.v1.Bundle;
+import java.io.Reader;
 import java.util.List;
 
 /**
@@ -50,5 +51,18 @@ public class BundleFactory {
       throw new IllegalArgumentException(
           "Can't serialize signing result to Sigstore Bundle JSON", e);
     }
+  }
+
+  /**
+   * Read a bundle json and convert it back into a keyless signing result for use within this
+   * library
+   *
+   * @param jsonReader a reader to a valid bundle json file
+   * @return the converted signing result object
+   * @throws BundleParseException if all or parts of the bundle were not convertible to library
+   *     types
+   */
+  public static KeylessSigningResult readBundle(Reader jsonReader) throws BundleParseException {
+    return BundleFactoryInternal.readBundle(jsonReader);
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleParseException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleParseException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.bundle;
+
+public class BundleParseException extends Exception {
+  public BundleParseException(String message) {
+    super(message);
+  }
+
+  public BundleParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BundleParseException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/Certificates.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/Certificates.java
@@ -55,6 +55,11 @@ public class Certificates {
     return fromPem(new String(cert, StandardCharsets.UTF_8));
   }
 
+  public static Certificate fromDer(byte[] cert) throws CertificateException {
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    return cf.generateCertificate(new ByteArrayInputStream(cert));
+  }
+
   /** Convert a CertPath to a PEM encoded certificate chain. */
   public static String toPemString(CertPath certs) throws IOException {
     var certWriter = new StringWriter();


### PR DESCRIPTION
Should probably rename KeylessSigningResult to something else (KeylessSignature or something). But that's for another day.