### PR TITLE
encryption: fix null-dereference

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
@@ -68,6 +68,9 @@ public class Keys {
           "sigstore public keys must be only a single PEM encoded public key");
     }
     // special handling for PKCS1 (rsa) public key
+    if (section == null) {
+      throw new InvalidKeySpecException("Invalid key");
+    }
     if (section.getType().equals("RSA PUBLIC KEY")) {
       ASN1Sequence sequence = ASN1Sequence.getInstance(section.getContent());
       ASN1Integer modulus = ASN1Integer.getInstance(sequence.getObjectAt(0));


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
sigstore-java's initial OSS-Fuzz integration found [a null-dereference](https://pipelines.actions.githubusercontent.com/serviceHosts/c6a67594-a987-4410-9dc3-fd69368975aa/_apis/pipelines/1/runs/29140/signedlogcontent/5?urlExpires=2023-03-13T20%3A25%3A31.9667606Z&urlSigningMethod=HMACV1&urlSignature=aykfEzh%2FYGa5cpIpKagYK8wCjilUgK7jKJR02GuZysc%3D#:~:text=at%20dev.sigstore.encryption.Keys.parsePublicKey(Keys.java%3A71)). This PR fixes that.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->