### PR TITLE
Fuzzing: fix build script to specify class path correctly

### DIFF
--- a/fuzzing/oss_fuzz_build.sh
+++ b/fuzzing/oss_fuzz_build.sh
@@ -15,7 +15,7 @@ ALL_JARS=sigstore-java.jar
 for jarfile in $(find ~/.gradle/caches/modules-2/files-2.1/ \( -iname "*.jar" ! -iname "junit*" ! -iname "spotless*" ! -iname "ktlint*" ! -iname "gradle*" ! -iname "kotlin*" \))
 do
   cp $jarfile $OUT/
-  ALL_JARS=$ALL_JARS:$(basename $jarfile)
+  ALL_JARS="$ALL_JARS $(basename $jarfile)"
 done
 
 # The classpath at build-time includes the project jars in $OUT as well as the

--- a/fuzzing/oss_fuzz_build.sh
+++ b/fuzzing/oss_fuzz_build.sh
@@ -44,7 +44,6 @@ else
 fi
 LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
 \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
---instrumentation_includes=com.sun.mail.** \
 --cp=$RUNTIME_CLASSPATH \
 --target_class=$fuzzer_basename \
 --jvm_args=\"\$mem_settings\" \


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This is to make the fuzzers run on the Clusterfuzz environment. 

Changes the classpath in the fuzzer-initiator script from:
`-cp=$this_dir/sigstore-java.jar:websocket-client-9.4.50.v20221201.jar: ...`
To:

`-cp=$this_dir/sigstore-java.jar:$this_dir/websocket-client-9.4.50.v20221201.jar: ...`

This is needed because Clusterfuzz will not guarantee the current working directory when launching the fuzzer, and more precisely it will not always be the same directory as where the fuzzers are placed.

CC @arthurscchan @AdamKorcz 

Fixes: https://github.com/sigstore/sigstore-java/issues/382
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->