### PR TITLE
Update tag-and-build-release.yaml

### DIFF
--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -107,5 +107,5 @@ jobs:
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # tag=v0.1.15
         with:
           tag_name: v${{ github.event.inputs.release_version }}
-          body: "See [CHANGELOG.md](https://github.com/${{ env.GITHUB_REPOSITORY }}/blob/main/CHANGELOG.md) for more details."
+          body: "See [CHANGELOG.md](https://github.com/${{ vars.GITHUB_REPOSITORY }}/blob/main/CHANGELOG.md) for more details."
           files: ./release/*


### PR DESCRIPTION
Fix problem with broken path in release notes

env.GITHUB_REPOSITORY is evaluated to "empty".
Configuration variables should be got with the vars context: https://docs.github.com/en/actions/learn-github-actions/variables#using-the-vars-context-to-access-configuration-variable-values

Btw, I didn't test it, but regarding to the linked documentation it should work (the current version definitely generates broken link: `https://github.com//blob/main/CHANGELOG.md` (see [v0.4.0](https://github.com/sigstore/sigstore-java/releases/tag/v0.4.0)).