### PR TITLE
Exception handling: Wrap illegal state exception

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
@@ -96,10 +96,10 @@ public class Keys {
     try {
       keyParameters = PublicKeyFactory.createKey(content);
     } catch (IllegalStateException e) {
-      throw new InvalidKeySpecException("Invlid key, could not parse PEM content");
+      throw new InvalidKeySpecException("Invalid key, could not parse PEM content");
     }
     if (keyParameters == null) {
-      throw new InvalidKeySpecException("Invlid key, could not parse PEM content");
+      throw new InvalidKeySpecException("Invalid key, could not parse PEM content");
     }
 
     // get algorithm inspecting the created class

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
@@ -90,7 +90,17 @@ public class Keys {
     // otherwise, we are dealing with PKIX X509 encoded keys
     byte[] content = section.getContent();
     EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(content);
-    AsymmetricKeyParameter keyParameters = PublicKeyFactory.createKey(content);
+    AsymmetricKeyParameter keyParameters = null;
+
+    // Ensure PEM content can be parsed correctly
+    try {
+      keyParameters = PublicKeyFactory.createKey(content);
+    } catch (IllegalStateException e) {
+      throw new InvalidKeySpecException("Invlid key, could not parse PEM content");
+    }
+    if (keyParameters == null) {
+      throw new InvalidKeySpecException("Invlid key, could not parse PEM content");
+    }
 
     // get algorithm inspecting the created class
     String keyAlgorithm = extractKeyAlgorithm(keyParameters);


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
For some malformed PEM section, the Base64 encoder of bouncy castle used by the sigstore java could throw an illegal state exception. As it is a runtime exception, JVM don’t requires it to be specifically caught, thus it does not appear in the auto-generated Javadoc and it is also assuming that exception should throw to the user. But since it is used by sigstore java as an API, it is better to wrap it with sigstore java exception.
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57336

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->