### PR TITLE
Fix: Fix possible Null Pointer Exception

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
@@ -94,6 +94,11 @@ public class Keys {
 
     // Ensure PEM content can be parsed correctly
     try {
+      // First byte of the content byte array is the tag and
+      // cannot be less than or equals to 0
+      if (byte[0] <= 0) {
+        throw new InvalidKeySpecException("Invalid key, could not parse PEM content");
+      } 
       keyParameters = PublicKeyFactory.createKey(content);
     } catch (IllegalStateException e) {
       throw new InvalidKeySpecException("Invalid key, could not parse PEM content");


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
In [PublicKeyFactory Line 108](https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/crypto/util/PublicKeyFactory.java#L108), SubjectPublicKeyInfo.getInstance method could return null and make [PublicKeyFactory Line 148](https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/crypto/util/PublicKeyFactory.java#L148) throws a NullPointerException. 

From [ASN1Primitive](https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/asn1/ASN1Primitive.java#L44-L51) and [ASN1InputStream](https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/asn1/ASN1InputStream.java#L189-L198), we know that if the tag (first  byte of the provided byte array) is a number less than 0, it will return null value and cause the null pointer exception. Thus the fix is to check if the first byte is less than or equals to 0 (it will throw IOException if the number is equals to 0) to ensure the SubjectPublicKeyInfo object is not null when creating the key.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57247
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->