### PR TITLE
Fixes: Add digest length checking

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/signers/EcdsaSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/signers/EcdsaSigner.java
@@ -43,6 +43,9 @@ public class EcdsaSigner implements Signer {
   @Override
   public byte[] signDigest(byte[] artifactDigest)
       throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+    if (artifactDigest.length > 64) {
+      throw new SignatureExeption("Artifact digest cannot be longer than 64 bytes for this mode");
+    }
     Signature signature = Signature.getInstance("NONEwithECDSA");
     signature.initSign(keyPair.getPrivate());
     signature.update(artifactDigest);

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/signers/EcdsaVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/signers/EcdsaVerifier.java
@@ -43,6 +43,9 @@ public class EcdsaVerifier implements Verifier {
   @Override
   public boolean verifyDigest(byte[] digest, byte[] signature)
       throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+    if (digest.length > 64) {
+      throw new SignatureExeption("Artifact digest cannot be longer than 64 bytes for this mode");
+    }
     var verifier = Signature.getInstance("NONEwithECDSA");
     verifier.initVerify(publicKey);
     verifier.update(digest);


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
According to the [ECDSASignature class](https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSASignature.java#L127), the NoneWithECDSA mode, the maximum length for the digest is 64, using a digest longer than 64 will result in ArrayIndexOutOfBoundException when the full byte array is copied to a byte array with only 64 bytes.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57360
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->