### PR TITLE
v1 tuf client

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -1,45 +1,78 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.sigstore.tuf;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Resources;
-import dev.sigstore.tuf.model.TargetMeta;
+import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.proto.trustroot.v1.TrustedRoot;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 
+/**
+ * Wrapper around {@link dev.sigstore.tuf.Updater} that provides access to sigstore specific
+ * metadata items in a convenient API.
+ */
 public class SigstoreTufClient {
+
+  @VisibleForTesting static final String TRUST_ROOT_FILENAME = "trusted_root.json";
 
   private Updater updater;
   private Instant lastUpdate;
-  private Map<String, byte[]> urlToKey = new HashMap<>();
+  private TrustedRoot sigstoreTrustedRoot;
+  private final Duration cacheValidity;
 
-
-  private SigstoreTufClient(Updater updater) {
+  @VisibleForTesting
+  SigstoreTufClient(Updater updater, Duration cacheValidity) {
     this.updater = updater;
+    this.cacheValidity = cacheValidity;
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 
   public static class Builder {
-    int cacheValidityDays = 1;
-    Path tufCacheLocation = Path.of("~/.sigstore-java/root");
+    Duration cacheValidity = Duration.ofDays(1);
+    Path tufCacheLocation =
+        Path.of(System.getProperty("user.home")).resolve(".sigstore-java").resolve("root");
 
     URL remoteMirror;
     Path trustedRoot;
 
     public Builder usePublicGoodInstance() {
       if (remoteMirror != null || trustedRoot != null) {
-        throw new IllegalStateException();
+        throw new IllegalStateException(
+            "Using public good after configuring remoteMirror and trustedRoot");
       }
-      try {5
-        tufMirror(new URL("https://storage.googleapis.com/sigstore-tuf-root/"), Path.of(Resources.getResource("dev/sigstore/tuf/sigstore-tuf-root/root.json").getPath()));
+      try {
+        tufMirror(
+            new URL("https://storage.googleapis.com/sigstore-tuf-root/"),
+            Path.of(
+                Resources.getResource("dev/sigstore/tuf/sigstore-tuf-root/root.json").getPath()));
       } catch (MalformedURLException e) {
         throw new AssertionError(e);
       }
@@ -52,8 +85,8 @@ public class SigstoreTufClient {
       return this;
     }
 
-    public Builder cacheValidation(int days) {
-      this.cacheValidityDays = days;
+    public Builder cacheValidity(Duration duration) {
+      this.cacheValidity = duration;
       return this;
     }
 
@@ -63,41 +96,49 @@ public class SigstoreTufClient {
     }
 
     public SigstoreTufClient build() throws IOException {
-      Preconditions.checkState(cacheValidityDays > 0);
+      Preconditions.checkState(!cacheValidity.isNegative(), "cacheValidity must be non negative");
       Preconditions.checkNotNull(remoteMirror);
       Preconditions.checkNotNull(trustedRoot);
       if (!Files.isDirectory(tufCacheLocation)) {
         Files.createDirectories(tufCacheLocation);
       }
-      var tufUpdater = Updater.builder().setTrustedRootPath(trustedRoot).setLocalStore(FileSystemTufStore.newFileSystemStore(tufCacheLocation)).setFetcher(HttpMetaFetcher.newFetcher(remoteMirror)).build();
-      return new SigstoreTufClient(tufUpdater);
+      var tufUpdater =
+          Updater.builder()
+              .setTrustedRootPath(trustedRoot)
+              .setLocalStore(FileSystemTufStore.newFileSystemStore(tufCacheLocation))
+              .setFetcher(HttpMetaFetcher.newFetcher(remoteMirror))
+              .build();
+      return new SigstoreTufClient(tufUpdater, cacheValidity);
     }
-
   }
 
-  public void initialize() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
-    updater.update();
+  /**
+   * Update the tuf metadata if the cache has not been updated for at least {@code cacheValidity}
+   * defined on the client.
+   */
+  public void update()
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+    if (lastUpdate == null
+        || Duration.between(lastUpdate, Instant.now()).compareTo(cacheValidity) > 0) {
+      this.forceUpdate();
+    }
   }
 
-  public void update() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+  /** Force an update, ignoring any cache validity. */
+  public void forceUpdate()
+      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
     updater.update();
     lastUpdate = Instant.now();
-    urlToKey.clear();
-    var targets = updater.getLocalStore().loadTargets().get().getSignedMeta().getTargets();
-    for (String fileName : targets.keySet()) {
-      TargetMeta.SigstoreMeta targetMeta = targets.get(fileName).getCustom().get().getSigstoreMeta();
-      if (targetMeta.getStatus().equals("ACTIVE")) {
-        urlToKey.put(targetMeta.getUri().get(), updater.getLocalStore().getTargetFile(fileName));
-      }
-    }
+    var trustedRootBuilder = TrustedRoot.newBuilder();
+    JsonFormat.parser()
+        .merge(
+            new String(
+                updater.getLocalStore().getTargetFile(TRUST_ROOT_FILENAME), StandardCharsets.UTF_8),
+            trustedRootBuilder);
+    sigstoreTrustedRoot = trustedRootBuilder.build();
   }
 
-  public Function<String, byte[]> getKeySupplier() {
-      return new Function<>() {
-        @Override
-        public byte[] apply(String input) {
-          return urlToKey.get(input);
-        }
-      };
+  public TrustedRoot getSigstoreTrustedRoot() {
+    return sigstoreTrustedRoot;
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+class SigstoreTufClientTest {
+
+  @TempDir Path localStorePath;
+
+  @Test
+  public void testUpdate_publicGoodHasTrustedRootJson() throws Exception {
+    var client =
+        SigstoreTufClient.builder()
+            .usePublicGoodInstance()
+            .tufCacheLocation(localStorePath)
+            .build();
+    client.forceUpdate();
+    Assertions.assertNotNull(client.getSigstoreTrustedRoot());
+  }
+
+  @Test
+  public void testUpdate_updateWhenCacheInvalid() throws Exception {
+    var mockUpdater = mockUpdater();
+    var client = new SigstoreTufClient(mockUpdater, Duration.ofSeconds(2));
+
+    client.update();
+    Thread.sleep(3000);
+    client.update();
+    Mockito.verify(mockUpdater, Mockito.times(2)).update();
+  }
+
+  @Test
+  public void testUpdate_noUpdateWhenCacheValid() throws Exception {
+    var mockUpdater = mockUpdater();
+    var client = new SigstoreTufClient(mockUpdater, Duration.ofSeconds(2));
+
+    client.update();
+    client.update();
+    Mockito.verify(mockUpdater, Mockito.times(1)).update();
+  }
+
+  private static Updater mockUpdater() throws IOException {
+    var trustRootBytes =
+        JsonFormat.printer().print(TrustedRoot.newBuilder()).getBytes(StandardCharsets.UTF_8);
+    var mockUpdater = Mockito.mock(Updater.class);
+    var mockTufStore = Mockito.mock(MutableTufStore.class);
+    Mockito.when(mockTufStore.getTargetFile(SigstoreTufClient.TRUST_ROOT_FILENAME))
+        .thenReturn(trustRootBytes);
+    Mockito.when(mockUpdater.getLocalStore()).thenReturn(mockTufStore);
+
+    return mockUpdater;
+  }
+}


### PR DESCRIPTION
Continuation of patricks work on this.

This is the sigstore wrapper around the Updater. It's very barebones right now, but it should allow us to easily access key/cert material defined in the trusted_root.json easier. This should also implement an interface that is passed to all verifiers (not yet defined).