### PR TITLE
Avoid failures on removal of published artifacts

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -96,9 +96,11 @@ abstract class SigstoreSignExtension(private val project: Project) {
         }
         publication.whenPublishableArtifactRemoved {
             val publishableArtifact = this
+            // Ignore artifacts that we have not added a signature for
+            val artifact = artifacts.remove(publishableArtifact) ?: return@whenPublishableArtifactRemoved
             signTask.configure {
-                signatures.findByName(file.name)
-                    ?.takeIf { publishableArtifact in it.builtBy  }
+                signatures.findByName(publishableArtifact.file.name)
+                    ?.takeIf { publishableArtifact in it.builtBy }
                     ?.let {
                         signatures.remove(it)
                         return@configure
@@ -106,7 +108,6 @@ abstract class SigstoreSignExtension(private val project: Project) {
                 // Slow path just in case
                 signatures.removeIf { publishableArtifact in it.builtBy }
             }
-            val artifact = artifacts.remove(publishableArtifact)
             publication.removeDerivedArtifact(artifact)
         }
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
In the Gradle sigstore plugin:
* Makes handling an artifact removal from the publication conditional to the plugin having derived a signature from it.

Unfortunately, testing this is quite messy as it would require a dual signing setup: sigstore + pgp. If required, I can add such a test. Ideally in a follow up PR as getting a version of the plugin released with this fix would be awesome. Conference driven development 😉 

Result with the 0.4.0 sigstore version can be seen in [this GH action run](https://github.com/ljacomet/logging-capabilities/actions/runs/4627732346/jobs/8185994950#step:5:56).

I have tested locally that the fix here allows to skip GPG signing of `*.sigstore` artifacts

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Fixes #414

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
NONE