### PR TITLE
chore: set version to 0.4.2 for proper release of sigstore-sign Gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 group=dev.sigstore
 # remember to update SigstoreSignExtension.kt when updating this
-version=0.5.0
+version=0.4.2

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -39,7 +39,7 @@ abstract class SigstoreSignExtension(private val project: Project) {
     abstract val sigstoreJavaVersion : Property<String>
 
     init {
-        sigstoreJavaVersion.convention("0.5.0")
+        sigstoreJavaVersion.convention("0.4.0")
         (this as ExtensionAware).extensions.create<OidcClientExtension>(
             "oidcClient",
             project.objects,


### PR DESCRIPTION
#### Summary

We need to have this change so the default `sigstore.sign` Gradle plugin would work