### PR TITLE
Add interfaces for sigstore trusted_root

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/proto/ProtoMutators.java
+++ b/sigstore-java/src/main/java/dev/sigstore/proto/ProtoMutators.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.proto;
+
+import com.google.protobuf.Timestamp;
+import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.proto.common.v1.X509Certificate;
+import java.security.cert.CertPath;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProtoMutators {
+
+  public static CertPath toCertPath(List<X509Certificate> certificates)
+      throws CertificateException {
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    List<Certificate> converted = new ArrayList<>(certificates.size());
+    for (var cert : certificates) {
+      converted.add(Certificates.fromDer(cert.getRawBytes().toByteArray()));
+    }
+    return cf.generateCertPath(converted);
+  }
+
+  public static Instant toInstant(Timestamp timestamp) {
+    return Instant.ofEpochSecond(timestamp.getSeconds(), timestamp.getNanos());
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/CertificateAuthority.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/CertificateAuthority.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import dev.sigstore.proto.ProtoMutators;
+import java.net.URI;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateException;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface CertificateAuthority {
+  CertPath getCertPath();
+
+  URI getUri();
+
+  ValidFor getValidFor();
+
+  Subject getSubject();
+
+  static CertificateAuthority from(dev.sigstore.proto.trustroot.v1.CertificateAuthority proto)
+      throws CertificateException {
+    return ImmutableCertificateAuthority.builder()
+        .certPath(ProtoMutators.toCertPath(proto.getCertChain().getCertificatesList()))
+        .validFor(ValidFor.from(proto.getValidFor()))
+        .uri(URI.create(proto.getUri()))
+        .subject(Subject.from(proto.getSubject()))
+        .build();
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/LogId.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/LogId.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface LogId {
+  byte[] getKeyId();
+
+  static LogId from(dev.sigstore.proto.common.v1.LogId proto) {
+    return ImmutableLogId.builder().keyId(proto.getKeyId().toByteArray()).build();
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/PublicKey.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/PublicKey.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import dev.sigstore.encryption.Keys;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface PublicKey {
+  byte[] getRawBytes();
+
+  String getKeyDetails();
+
+  ValidFor getValidFor();
+
+  static PublicKey from(dev.sigstore.proto.common.v1.PublicKey proto) {
+    return ImmutablePublicKey.builder()
+        .rawBytes(proto.getRawBytes().toByteArray())
+        .keyDetails(proto.getKeyDetails().name())
+        .validFor(ValidFor.from(proto.getValidFor()))
+        .build();
+  }
+
+  static java.security.PublicKey toJavaPublicKey(PublicKey publicKey)
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    if (!publicKey.getKeyDetails().equals("PKIX_ECDSA_P256_SHA_256")) {
+      throw new InvalidKeySpecException("Unsupported key algorithm: " + publicKey.getKeyDetails());
+    }
+    return Keys.parsePkixPublicKey(publicKey.getRawBytes(), "EC");
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/SigstoreTrustedRoot.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/SigstoreTrustedRoot.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface SigstoreTrustedRoot {
+
+  List<CertificateAuthority> getCertificateAuthorities();
+
+  List<TransparencyLog> getTLogs();
+
+  List<TransparencyLog> getCTLogs();
+
+  static SigstoreTrustedRoot from(TrustedRoot proto) throws CertificateException {
+    List<CertificateAuthority> certificateAuthorities =
+        new ArrayList<>(proto.getCertificateAuthoritiesCount());
+    for (var certAuthority : proto.getCertificateAuthoritiesList()) {
+      certificateAuthorities.add(CertificateAuthority.from(certAuthority));
+    }
+    var tlogs =
+        proto.getTlogsList().stream().map(TransparencyLog::from).collect(Collectors.toList());
+    var ctlogs =
+        proto.getCtlogsList().stream().map(TransparencyLog::from).collect(Collectors.toList());
+
+    return ImmutableSigstoreTrustedRoot.builder()
+        .certificateAuthorities(certificateAuthorities)
+        .tLogs(tlogs)
+        .cTLogs(ctlogs)
+        .build();
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/Subject.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/Subject.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import dev.sigstore.proto.common.v1.DistinguishedName;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+interface Subject {
+  String getOrganization();
+
+  String getCommonName();
+
+  static Subject from(DistinguishedName proto) {
+    return ImmutableSubject.builder()
+        .commonName(proto.getCommonName())
+        .organization(proto.getOrganization())
+        .build();
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLog.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLog.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import static org.immutables.value.Value.*;
+
+import dev.sigstore.proto.trustroot.v1.TransparencyLogInstance;
+import java.net.URI;
+
+@Immutable
+public interface TransparencyLog {
+  URI getBaseUrl();
+
+  String getHashAlgorithm();
+
+  LogId getLogId();
+
+  PublicKey getPublicKey();
+
+  static TransparencyLog from(TransparencyLogInstance proto) {
+    return ImmutableTransparencyLog.builder()
+        .baseUrl(URI.create(proto.getBaseUrl()))
+        .hashAlgorithm(proto.getHashAlgorithm().name())
+        .logId(LogId.from(proto.getLogId()))
+        .publicKey(PublicKey.from(proto.getPublicKey()))
+        .build();
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/ValidFor.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/ValidFor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import dev.sigstore.proto.ProtoMutators;
+import dev.sigstore.proto.common.v1.TimeRange;
+import java.time.Instant;
+import java.util.Optional;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+public interface ValidFor {
+  Instant getStart();
+
+  Optional<Instant> getEnd();
+
+  static ValidFor from(TimeRange proto) {
+    return ImmutableValidFor.builder()
+        .start(ProtoMutators.toInstant(proto.getStart()))
+        .end(
+            proto.hasEnd()
+                ? Optional.of(ProtoMutators.toInstant(proto.getEnd()))
+                : Optional.empty())
+        .build();
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.io.Resources;
+import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.jupiter.api.Test;
+
+class SigstoreTrustedRootTest {
+
+  @Test
+  void from_prod() throws Exception {
+    var json =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/trustroot/trusted_root.json"),
+            StandardCharsets.UTF_8);
+    var builder = TrustedRoot.newBuilder();
+    JsonFormat.parser().merge(json, builder);
+
+    var trustRoot = SigstoreTrustedRoot.from(builder.build());
+
+    assertEquals(2, trustRoot.getCertificateAuthorities().size());
+    assertEquals(1, trustRoot.getTLogs().size());
+    assertEquals(2, trustRoot.getCTLogs().size());
+
+    var oldCA = trustRoot.getCertificateAuthorities().get(0);
+    assertEquals("sigstore", oldCA.getSubject().getCommonName());
+    assertEquals("sigstore.dev", oldCA.getSubject().getOrganization());
+    assertEquals(
+        ZonedDateTime.parse("2021-03-07T03:20:29.000Z").toInstant(),
+        oldCA.getValidFor().getStart());
+    assertEquals(
+        ZonedDateTime.parse("2022-12-31T23:59:59.999Z").toInstant(),
+        oldCA.getValidFor().getEnd().get());
+    assertEquals(
+        "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==",
+        Base64.toBase64String(oldCA.getCertPath().getCertificates().get(0).getEncoded()));
+    assertNotNull(oldCA.getCertPath());
+
+    var currCA = trustRoot.getCertificateAuthorities().get(1);
+    assertEquals("sigstore", currCA.getSubject().getCommonName());
+    assertEquals("sigstore.dev", currCA.getSubject().getOrganization());
+    assertEquals(
+        ZonedDateTime.parse("2022-04-13T20:06:15.000Z").toInstant(),
+        currCA.getValidFor().getStart());
+    assertTrue(currCA.getValidFor().getEnd().isEmpty());
+    assertEquals(
+        "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow=",
+        Base64.toBase64String(currCA.getCertPath().getCertificates().get(0).getEncoded()));
+    assertEquals(
+        "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ",
+        Base64.toBase64String(currCA.getCertPath().getCertificates().get(1).getEncoded()));
+    assertNotNull(currCA.getCertPath());
+
+    var tlog = trustRoot.getTLogs().get(0);
+    assertEquals("https://rekor.sigstore.dev", tlog.getBaseUrl().toString());
+    assertEquals("SHA2_256", tlog.getHashAlgorithm());
+    assertEquals(
+        ZonedDateTime.parse("2021-01-12T11:53:27.000Z").toInstant(),
+        tlog.getPublicKey().getValidFor().getStart());
+    assertTrue(tlog.getPublicKey().getValidFor().getEnd().isEmpty());
+    assertEquals(
+        "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=",
+        Base64.toBase64String(tlog.getLogId().getKeyId()));
+    assertEquals(
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==",
+        Base64.toBase64String(PublicKey.toJavaPublicKey(tlog.getPublicKey()).getEncoded()));
+
+    var oldCTLog = trustRoot.getCTLogs().get(0);
+    assertEquals("https://ctfe.sigstore.dev/test", oldCTLog.getBaseUrl().toString());
+    assertEquals("SHA2_256", oldCTLog.getHashAlgorithm());
+    assertEquals(
+        ZonedDateTime.parse("2021-03-14T00:00:00.000Z").toInstant(),
+        oldCTLog.getPublicKey().getValidFor().getStart());
+    assertEquals(
+        ZonedDateTime.parse("2022-10-31T23:59:59.999Z").toInstant(),
+        oldCTLog.getPublicKey().getValidFor().getEnd().get());
+    assertEquals(
+        "CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I=",
+        Base64.toBase64String(oldCTLog.getLogId().getKeyId()));
+    assertEquals(
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
+        Base64.toBase64String(PublicKey.toJavaPublicKey(oldCTLog.getPublicKey()).getEncoded()));
+
+    var currCTLog = trustRoot.getCTLogs().get(1);
+    assertEquals("https://ctfe.sigstore.dev/2022", currCTLog.getBaseUrl().toString());
+    assertEquals("SHA2_256", currCTLog.getHashAlgorithm());
+    assertEquals(
+        ZonedDateTime.parse("2022-10-20T00:00:00.000Z").toInstant(),
+        currCTLog.getPublicKey().getValidFor().getStart());
+    assertTrue(currCTLog.getPublicKey().getValidFor().getEnd().isEmpty());
+    assertEquals(
+        "3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4=",
+        Base64.toBase64String(currCTLog.getLogId().getKeyId()));
+    assertEquals(
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
+        Base64.toBase64String(PublicKey.toJavaPublicKey(currCTLog.getPublicKey()).getEncoded()));
+  }
+}

--- a/sigstore-java/src/test/resources/dev/sigstore/trustroot/README.me
+++ b/sigstore-java/src/test/resources/dev/sigstore/trustroot/README.me
@@ -1,0 +1,2 @@
+trusted_root.json was pulled from prod in April 2023
+https://github.com/sigstore/root-signing/blob/f50a9debad1db8c4e44d571147968c4061344f5f/targets/trusted_root.json

--- a/sigstore-java/src/test/resources/dev/sigstore/trustroot/trusted_root.json
+++ b/sigstore-java/src/test/resources/dev/sigstore/trustroot/trusted_root.json
@@ -1,0 +1,114 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+  "tlogs": [
+    {
+      "baseUrl": "https://rekor.sigstore.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-01-12T11:53:27.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+      }
+    }
+  ],
+  "certificateAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstore.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ=="
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2021-03-07T03:20:29.000Z",
+        "end": "2022-12-31T23:59:59.999Z"
+      }
+    },
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstore.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow="
+          },
+          {
+            "rawBytes": "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ"
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2022-04-13T20:06:15.000Z"
+      }
+    }
+  ],
+  "ctlogs": [
+    {
+      "baseUrl": "https://ctfe.sigstore.dev/test",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-03-14T00:00:00.000Z",
+          "end": "2022-10-31T23:59:59.999Z"
+        }
+      },
+      "logId": {
+        "keyId": "CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstore.dev/2022",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-10-20T00:00:00.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4="
+      }
+    }
+  ],
+  "timestampAuthorities": [
+    {
+      "subject": {
+        "organization": "GitHub, Inc.",
+        "commonName": "Internal Services Root"
+      },
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIIB3DCCAWKgAwIBAgIUchkNsH36Xa04b1LqIc+qr9DVecMwCgYIKoZIzj0EAwMwMjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMRkwFwYDVQQDExBUU0EgaW50ZXJtZWRpYXRlMB4XDTIzMDQxNDAwMDAwMFoXDTI0MDQxMzAwMDAwMFowMjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMRkwFwYDVQQDExBUU0EgVGltZXN0YW1waW5nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUD5ZNbSqYMd6r8qpOOEX9ibGnZT9GsuXOhr/f8U9FJugBGExKYp40OULS0erjZW7xV9xV52NnJf5OeDq4e5ZKqNWMFQwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMIMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUaW1RudOgVt0leqY0WKYbuPr47wAwCgYIKoZIzj0EAwMDaAAwZQIwbUH9HvD4ejCZJOWQnqAlkqURllvu9M8+VqLbiRK+zSfZCZwsiljRn8MQQRSkXEE5AjEAg+VxqtojfVfu8DhzzhCx9GKETbJHb19iV72mMKUbDAFmzZ6bQ8b54Zb8tidy5aWe"
+          },
+          {
+            "rawBytes": "MIICEDCCAZWgAwIBAgIUX8ZO5QXP7vN4dMQ5e9sU3nub8OgwCgYIKoZIzj0EAwMwODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZJbnRlcm5hbCBTZXJ2aWNlcyBSb290MB4XDTIzMDQxNDAwMDAwMFoXDTI4MDQxMjAwMDAwMFowMjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMRkwFwYDVQQDExBUU0EgaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvMLY/dTVbvIJYANAuszEwJnQE1llftynyMKIMhh48HmqbVr5ygybzsLRLVKbBWOdZ21aeJz+gZiytZetqcyF9WlER5NEMf6JV7ZNojQpxHq4RHGoGSceQv/qvTiZxEDKo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUaW1RudOgVt0leqY0WKYbuPr47wAwHwYDVR0jBBgwFoAU9NYYlobnAG4c0/qjxyH/lq/wz+QwCgYIKoZIzj0EAwMDaQAwZgIxAK1B185ygCrIYFlIs3GjswjnwSMG6LY8woLVdakKDZxVa8f8cqMs1DhcxJ0+09w95QIxAO+tBzZk7vjUJ9iJgD4R6ZWTxQWKqNm74jO99o+o9sv4FI/SZTZTFyMn0IJEHdNmyA=="
+          },
+          {
+            "rawBytes": "MIIB9DCCAXqgAwIBAgIUa/JAkdUjK4JUwsqtaiRJGWhqLSowCgYIKoZIzj0EAwMwODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZJbnRlcm5hbCBTZXJ2aWNlcyBSb290MB4XDTIzMDQxNDAwMDAwMFoXDTMzMDQxMTAwMDAwMFowODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZJbnRlcm5hbCBTZXJ2aWNlcyBSb290MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEf9jFAXxz4kx68AHRMOkFBhflDcMTvzaXz4x/FCcXjJ/1qEKon/qPIGnaURskDtyNbNDOpeJTDDFqt48iMPrnzpx6IZwqemfUJN4xBEZfza+pYt/iyod+9tZr20RRWSv/o0UwQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBAjAdBgNVHQ4EFgQU9NYYlobnAG4c0/qjxyH/lq/wz+QwCgYIKoZIzj0EAwMDaAAwZQIxALZLZ8BgRXzKxLMMN9VIlO+e4hrBnNBgF7tz7Hnrowv2NetZErIACKFymBlvWDvtMAIwZO+ki6ssQ1bsZo98O8mEAf2NZ7iiCgDDU0Vwjeco6zyeh0zBTs9/7gV6AHNQ53xD"
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2023-04-14T00:00:00.000Z"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This should allow us to use it as the source for all validation materials from TUF.

