### PR TITLE
Add accessors to trustroot

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/Certificates.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/Certificates.java
@@ -23,6 +23,8 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.*;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 
 public class Certificates {
@@ -55,9 +57,20 @@ public class Certificates {
     return fromPem(new String(cert, StandardCharsets.UTF_8));
   }
 
+  /** Convert a single der encoded cert to Certificate. */
   public static Certificate fromDer(byte[] cert) throws CertificateException {
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
     return cf.generateCertificate(new ByteArrayInputStream(cert));
+  }
+
+  /** Convert a lit of der encoded certs to CertPath. */
+  public static CertPath fromDer(List<byte[]> certChain) throws CertificateException {
+    List<Certificate> certificates = new ArrayList<>(certChain.size());
+    for (var cert : certChain) {
+      certificates.add(fromDer(cert));
+    }
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    return cf.generateCertPath(certificates);
   }
 
   /** Convert a CertPath to a PEM encoded certificate chain. */
@@ -115,5 +128,11 @@ public class Certificates {
   /** Convert a PEM encoded certificate chain to a {@link CertPath}. */
   public static CertPath fromPemChain(byte[] certs) throws CertificateException {
     return fromPemChain(new String(certs, StandardCharsets.UTF_8));
+  }
+
+  /** Converts a single X509Certificate to a {@link CertPath}. */
+  public static CertPath toCertPath(Certificate certificate) throws CertificateException {
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    return cf.generateCertPath(Collections.singletonList(certificate));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/CertificateAuthorities.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/CertificateAuthorities.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@Value.Style(
+    depluralize = true,
+    depluralizeDictionary = {"certificateAuthority:certificateAuthorities"})
+public abstract class CertificateAuthorities {
+
+  public abstract List<CertificateAuthority> getCertificateAuthorities();
+
+  @Derived
+  public int size() {
+    return getCertificateAuthorities().size();
+  }
+
+  @Derived
+  public List<CertificateAuthority> all() {
+    return getCertificateAuthorities();
+  }
+
+  /**
+   * Find a CA by validity time, users of this method will need to then compare the key in the leaf
+   * to find the exact CA to validate against
+   *
+   * @param time the time the CA was expected to be valid (usually tlog entry time)
+   * @return a list of CAs that were valid at {@code time}
+   */
+  public List<CertificateAuthority> find(Instant time) {
+    return getCertificateAuthorities().stream()
+        .filter(ca -> ca.getValidFor().getStart().compareTo(time) <= 0)
+        .filter(ca -> ca.getValidFor().getEnd().orElse(Instant.now()).compareTo(time) >= 0)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Get the one an only current Certificate Authority
+   *
+   * @return the current active CA
+   * @throws IllegalStateException if trust root does not contain exactly one active CA
+   */
+  public CertificateAuthority current() {
+    var current =
+        getCertificateAuthorities().stream()
+            .filter(ca -> ca.getValidFor().getEnd().isEmpty())
+            .collect(Collectors.toList());
+    if (current.size() == 0) {
+      throw new IllegalStateException("Trust root contains no current certificate authorities");
+    }
+    if (current.size() > 1) {
+      throw new IllegalStateException(
+          "Trust root contains multiple current certificate authorities (" + current.size() + ")");
+    }
+    return current.get(0);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLogs.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLogs.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@Value.Style(depluralize = true)
+public abstract class TransparencyLogs {
+
+  public abstract List<TransparencyLog> getTransparencyLogs();
+
+  @Derived
+  public int size() {
+    return getTransparencyLogs().size();
+  }
+
+  @Derived
+  public List<TransparencyLog> all() {
+    return getTransparencyLogs();
+  }
+
+  public TransparencyLog current() {
+    var current =
+        getTransparencyLogs().stream()
+            .filter(tl -> tl.getPublicKey().getValidFor().getEnd().isEmpty())
+            .collect(Collectors.toList());
+    if (current.size() == 0) {
+      throw new IllegalStateException("Trust root contains no current transparency logs");
+    }
+    if (current.size() > 1) {
+      throw new IllegalStateException(
+          "Trust root contains multiple current transparency logs (" + current.size() + ")");
+    }
+    return current.get(0);
+  }
+
+  public Optional<TransparencyLog> find(byte[] logId, Instant time) {
+    return getTransparencyLogs().stream()
+        .filter(tl -> Arrays.equals(tl.getLogId().getKeyId(), logId))
+        .filter(tl -> tl.getPublicKey().getValidFor().getStart().compareTo(time) <= 0)
+        .filter(
+            tl ->
+                tl.getPublicKey().getValidFor().getEnd().orElse(Instant.now()).compareTo(time) >= 0)
+        .findAny();
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/encryption/certificates/CertificatesTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/encryption/certificates/CertificatesTest.java
@@ -19,6 +19,9 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.List;
+import org.bouncycastle.util.encoders.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -93,5 +96,38 @@ public class CertificatesTest {
   public void fromPemChain_garbage() throws IOException {
     var pemString = "garbage";
     Assertions.assertThrows(CertificateException.class, () -> Certificates.fromPemChain(pemString));
+  }
+
+  @Test
+  public void fromDer() throws Exception {
+    var derCert =
+        Base64.decode(
+            "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==");
+    Assertions.assertNotNull(Certificates.fromDer(derCert));
+  }
+
+  @Test
+  public void fromDer_certPath() throws Exception {
+    List<byte[]> certs = new ArrayList<>(2);
+    certs.add(
+        0,
+        Base64.decode(
+            "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow="));
+    certs.add(
+        1,
+        Base64.decode(
+            "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ"));
+    Assertions.assertEquals(2, Certificates.fromDer(certs).getCertificates().size());
+  }
+
+  @Test
+  public void toCertPath() throws Exception {
+    var cert =
+        Certificates.fromDer(
+            Base64.decode(
+                "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ=="));
+    var certPath = Certificates.toCertPath(cert);
+    Assertions.assertEquals(1, certPath.getCertificates().size());
+    Assertions.assertEquals(cert, certPath.getCertificates().get(0));
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/CertificateAuthoritiesTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/CertificateAuthoritiesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.security.cert.CertPath;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class CertificateAuthoritiesTest {
+  @Test
+  public void current_missing() {
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> ImmutableCertificateAuthorities.builder().build().current());
+  }
+
+  @Test
+  public void current_tooMany() {
+    var ca =
+        ImmutableCertificateAuthority.builder()
+            .certPath(Mockito.mock(CertPath.class))
+            .uri(URI.create("abc"))
+            .subject(ImmutableSubject.builder().commonName("abc").organization("xyz").build())
+            .validFor(
+                ImmutableValidFor.builder()
+                    .start(Instant.now().minus(10, ChronoUnit.SECONDS))
+                    .build())
+            .build();
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () ->
+            ImmutableCertificateAuthorities.builder()
+                .addCertificateAuthorities(ca, ca)
+                .build()
+                .current());
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
@@ -15,22 +15,34 @@
  */
 package dev.sigstore.trustroot;
 
+import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.io.Resources;
 import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.bouncycastle.util.encoders.Base64;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class SigstoreTrustedRootTest {
 
-  @Test
-  void from_prod() throws Exception {
+  private static SigstoreTrustedRoot trustRoot;
+
+  @BeforeAll
+  public static void initTrustRoot() throws IOException, CertificateException {
     var json =
         Resources.toString(
             Resources.getResource("dev/sigstore/trustroot/trusted_root.json"),
@@ -38,13 +50,16 @@ class SigstoreTrustedRootTest {
     var builder = TrustedRoot.newBuilder();
     JsonFormat.parser().merge(json, builder);
 
-    var trustRoot = SigstoreTrustedRoot.from(builder.build());
+    trustRoot = SigstoreTrustedRoot.from(builder.build());
+  }
 
-    assertEquals(2, trustRoot.getCertificateAuthorities().size());
+  @Test
+  void from_checkFields() throws Exception {
+    assertEquals(2, trustRoot.getCAs().size());
     assertEquals(1, trustRoot.getTLogs().size());
     assertEquals(2, trustRoot.getCTLogs().size());
 
-    var oldCA = trustRoot.getCertificateAuthorities().get(0);
+    var oldCA = trustRoot.getCAs().all().get(0);
     assertEquals("sigstore", oldCA.getSubject().getCommonName());
     assertEquals("sigstore.dev", oldCA.getSubject().getOrganization());
     assertEquals(
@@ -58,7 +73,7 @@ class SigstoreTrustedRootTest {
         Base64.toBase64String(oldCA.getCertPath().getCertificates().get(0).getEncoded()));
     assertNotNull(oldCA.getCertPath());
 
-    var currCA = trustRoot.getCertificateAuthorities().get(1);
+    var currCA = trustRoot.getCAs().all().get(1);
     assertEquals("sigstore", currCA.getSubject().getCommonName());
     assertEquals("sigstore.dev", currCA.getSubject().getOrganization());
     assertEquals(
@@ -73,7 +88,7 @@ class SigstoreTrustedRootTest {
         Base64.toBase64String(currCA.getCertPath().getCertificates().get(1).getEncoded()));
     assertNotNull(currCA.getCertPath());
 
-    var tlog = trustRoot.getTLogs().get(0);
+    var tlog = trustRoot.getTLogs().getTransparencyLogs().get(0);
     assertEquals("https://rekor.sigstore.dev", tlog.getBaseUrl().toString());
     assertEquals("SHA2_256", tlog.getHashAlgorithm());
     assertEquals(
@@ -87,7 +102,7 @@ class SigstoreTrustedRootTest {
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==",
         Base64.toBase64String(PublicKey.toJavaPublicKey(tlog.getPublicKey()).getEncoded()));
 
-    var oldCTLog = trustRoot.getCTLogs().get(0);
+    var oldCTLog = trustRoot.getCTLogs().all().get(0);
     assertEquals("https://ctfe.sigstore.dev/test", oldCTLog.getBaseUrl().toString());
     assertEquals("SHA2_256", oldCTLog.getHashAlgorithm());
     assertEquals(
@@ -103,7 +118,7 @@ class SigstoreTrustedRootTest {
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
         Base64.toBase64String(PublicKey.toJavaPublicKey(oldCTLog.getPublicKey()).getEncoded()));
 
-    var currCTLog = trustRoot.getCTLogs().get(1);
+    var currCTLog = trustRoot.getCTLogs().all().get(1);
     assertEquals("https://ctfe.sigstore.dev/2022", currCTLog.getBaseUrl().toString());
     assertEquals("SHA2_256", currCTLog.getHashAlgorithm());
     assertEquals(
@@ -116,5 +131,162 @@ class SigstoreTrustedRootTest {
     assertEquals(
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
         Base64.toBase64String(PublicKey.toJavaPublicKey(currCTLog.getPublicKey()).getEncoded()));
+  }
+
+  @Test
+  public void getTlog_isPresent() {
+    var key = Base64.decode("wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=");
+
+    // exactly at start time
+    assertTLogEntryIsPresent(
+        trustRoot.getTLogs()::find, key, ZonedDateTime.parse("2021-01-12T11:53:27.000Z"));
+    // other random time
+    assertTLogEntryIsPresent(
+        trustRoot.getTLogs()::find, key, ZonedDateTime.parse("2021-12-12T11:53:27.000Z"));
+  }
+
+  @Test
+  public void getTlog_isNotPresent() {
+    // before the start time, but valid key
+    assertTLogEntryIsEmpty(
+        trustRoot.getTLogs()::find,
+        Base64.decode("wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="),
+        ZonedDateTime.parse("2021-01-01T11:53:27.000Z"));
+
+    // valid time but bad key
+    assertTLogEntryIsEmpty(
+        trustRoot.getTLogs()::find,
+        Base64.decode("wNI8atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="),
+        ZonedDateTime.parse("2021-12-12T11:53:27.000Z"));
+  }
+
+  @Test
+  public void getCurrentTLog() {
+    var tlog = trustRoot.getTLogs().current();
+    assertArrayEquals(
+        Base64.decode("wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="), tlog.getLogId().getKeyId());
+  }
+
+  @Test
+  public void getCurrentCTLog() {
+    var ctlog = trustRoot.getCTLogs().current();
+    assertArrayEquals(
+        Base64.decode("3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4="), ctlog.getLogId().getKeyId());
+  }
+
+  @Test
+  public void getCTLog_isPresent() {
+    var key = Base64.decode("CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I=");
+
+    // exactly at start
+    assertTLogEntryIsPresent(
+        trustRoot.getCTLogs()::find, key, ZonedDateTime.parse("2021-03-14T00:00:00.000Z"));
+    // in the middle
+    assertTLogEntryIsPresent(
+        trustRoot.getCTLogs()::find, key, ZonedDateTime.parse("2021-10-14T00:00:00.000Z"));
+    // exactly at end time
+    assertTLogEntryIsPresent(
+        trustRoot.getCTLogs()::find, key, ZonedDateTime.parse("2022-10-31T23:59:59.999Z"));
+  }
+
+  @Test
+  public void getCTLog_isNotPresent() {
+    var key = Base64.decode("CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I=");
+
+    // before the start time, but valid key
+    assertTLogEntryIsEmpty(
+        trustRoot.getCTLogs()::find, key, ZonedDateTime.parse("2019-01-01T11:53:27.000Z"));
+
+    // after end time, but valid key
+    assertTLogEntryIsEmpty(
+        trustRoot.getCTLogs()::find, key, ZonedDateTime.parse("2022-11-01T11:53:27.000Z"));
+
+    // garbage key
+    assertTLogEntryIsEmpty(
+        trustRoot.getCTLogs()::find,
+        Base64.decode("wNI8atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="),
+        ZonedDateTime.parse("2021-10-14T00:00:00.000Z"));
+  }
+
+  @Test
+  public void getCAs_isPresent() {
+    // exactly at start
+    assertEquals(
+        1,
+        trustRoot
+            .getCAs()
+            .find(ZonedDateTime.parse("2021-03-07T03:20:29.000Z").toInstant())
+            .size());
+    // somewhere in the middle
+    assertEquals(
+        1,
+        trustRoot
+            .getCAs()
+            .find(ZonedDateTime.parse("2021-04-28T03:59:59.999Z").toInstant())
+            .size());
+    // exactly at end but also overlapping with another CA
+    assertEquals(
+        2,
+        trustRoot
+            .getCAs()
+            .find(ZonedDateTime.parse("2022-12-31T23:59:59.999Z").toInstant())
+            .size());
+  }
+
+  @Test
+  public void getCAs_isNotPresent() {
+    assertEquals(
+        0,
+        trustRoot
+            .getCAs()
+            .find(ZonedDateTime.parse("2015-03-14T00:00:00.000Z").toInstant())
+            .size());
+  }
+
+  @Test
+  public void getCurrentCA() throws CertificateException {
+    var ca = trustRoot.getCAs().current();
+    List<byte[]> certs = new ArrayList<>(2);
+    certs.add(
+        0,
+        Base64.decode(
+            "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow="));
+    certs.add(
+        1,
+        Base64.decode(
+            "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ"));
+    var certPath = Certificates.fromDer(certs);
+    assertEquals(certPath, ca.getCertPath());
+  }
+
+  @FunctionalInterface
+  private interface TLogQuery {
+    Optional<TransparencyLog> find(byte[] key, Instant time);
+  }
+
+  private void assertTLogEntryIsPresent(TLogQuery query, byte[] key, ZonedDateTime time) {
+    if (query.find(key, time.toInstant()).isEmpty()) {
+      assertionFailure()
+          .reason(
+              "expected: tlog is found: key_id("
+                  + Base64.toBase64String(key)
+                  + "), time("
+                  + time
+                  + ")")
+          .buildAndThrow();
+    }
+  }
+
+  private void assertTLogEntryIsEmpty(TLogQuery query, byte[] key, ZonedDateTime time) {
+    if (query.find(key, time.toInstant()).isPresent()) {
+      assertionFailure()
+          .reason(
+              "expected: tlog is not found: key_id("
+                  + Base64.toBase64String(key)
+                  + "), time("
+                  + time
+                  + ")")
+          .buildAndThrow();
+    }
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/TransparencyLogsTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/TransparencyLogsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.trustroot;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TransparencyLogsTest {
+
+  @Test
+  public void current_missing() {
+    Assertions.assertThrows(
+        IllegalStateException.class, () -> ImmutableTransparencyLogs.builder().build().current());
+  }
+
+  @Test
+  public void current_tooMany() {
+    var pk = Mockito.mock(PublicKey.class);
+    Mockito.when(pk.getValidFor())
+        .thenReturn(
+            ImmutableValidFor.builder().start(Instant.now().minus(10, ChronoUnit.SECONDS)).build());
+    var tlog =
+        ImmutableTransparencyLog.builder()
+            .logId(Mockito.mock(LogId.class))
+            .baseUrl(URI.create("abc"))
+            .hashAlgorithm("sha256")
+            .publicKey(pk)
+            .build();
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () ->
+            ImmutableTransparencyLogs.builder().addTransparencyLogs(tlog, tlog).build().current());
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
@@ -39,6 +39,10 @@ class SigstoreTufClientTest {
             .build();
     client.forceUpdate();
     Assertions.assertNotNull(client.getSigstoreTrustedRoot());
+
+    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getTLogs().current());
+    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getCTLogs().current());
+    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getCAs().current());
   }
 
   @Test


### PR DESCRIPTION
We need to be able to query the trustroot for CAs and logs to initialize our signers and based on the material we are signing.

This will eventually allow us to init a client directly from a trustroot
