### PR TITLE
Bump `sigstore-conformance` to 0.0.4

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Unpack sigstore-java distribution
         run: tar -xvf ${{ github.workspace }}/sigstore-cli/build/distributions/sigstore-cli-*.tar --strip-components 1
 
-      - uses: trailofbits/sigstore-conformance@064fb32a890c30235f305281f3509c5e65e6f9e5 # v0.0.4
+      - uses: sigstore/sigstore-conformance@064fb32a890c30235f305281f3509c5e65e6f9e5 # tag=v0.0.4
         with:
           entrypoint: ${{ github.workspace }}/bin/sigstore-cli

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,9 +14,6 @@ jobs:
         java-version: [11, 17]
       fail-fast: false
 
-    permissions:
-      # Needed to access the workflow's OIDC identity.
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    types: [labeled]
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -3,9 +3,8 @@ name: Conformance Tests
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
-  workflow_dispatch:
 
 jobs:
   conformance:

--- a/sigstore-cli/build.gradle.kts
+++ b/sigstore-cli/build.gradle.kts
@@ -12,6 +12,9 @@ dependencies {
     implementation("info.picocli:picocli:4.7.3")
     implementation("com.google.guava:guava:31.1-jre")
 
+    implementation(platform("com.google.oauth-client:google-oauth-client-bom:1.34.1"))
+    implementation("com.google.oauth-client:google-oauth-client")
+
     annotationProcessor("info.picocli:picocli-codegen:4.7.3")
 }
 

--- a/sigstore-cli/src/main/java/dev/sigstore/cli/Sign.java
+++ b/sigstore-cli/src/main/java/dev/sigstore/cli/Sign.java
@@ -19,7 +19,6 @@ import dev.sigstore.KeylessSigner;
 import dev.sigstore.bundle.BundleFactory;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.oidc.client.OidcClients;
-import dev.sigstore.oidc.client.TokenStringOidcClient;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/sigstore-cli/src/main/java/dev/sigstore/cli/TokenStringOidcClient.java
+++ b/sigstore-cli/src/main/java/dev/sigstore/cli/TokenStringOidcClient.java
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.sigstore.oidc.client;
+package dev.sigstore.cli;
 
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
+import dev.sigstore.oidc.client.ImmutableOidcToken;
+import dev.sigstore.oidc.client.OidcClient;
+import dev.sigstore.oidc.client.OidcException;
+import dev.sigstore.oidc.client.OidcToken;
 import java.io.IOException;
 
 public class TokenStringOidcClient implements OidcClient {

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/TokenStringOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/TokenStringOidcClient.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import java.io.IOException;
+
+public class TokenStringOidcClient implements OidcClient {
+
+  private final String idToken;
+
+  public TokenStringOidcClient(String idToken) {
+    this.idToken = idToken;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public OidcToken getIDToken() throws OidcException {
+    try {
+      var jws = JsonWebSignature.parse(new GsonFactory(), idToken);
+      return ImmutableOidcToken.builder()
+          .idToken(idToken)
+          .subjectAlternativeName(jws.getPayload().getSubject())
+          .build();
+    } catch (IOException e) {
+      throw new OidcException("Failed to parse JWT", e);
+    }
+  }
+}


### PR DESCRIPTION
There's been a few changes since the last release.

We've figured out a new scheme for getting OIDC tokens. This means:

- We no longer need to give third-party PRs access to secrets via `pull_request_target`.
- We no longer need a "safe to test" label to protect against third-party PRs maliciously using secrets.

The way it works is that we have a separate PR that is separated from the Sigstore org that is responsible for continually generating OIDC tokens. The conformance suite will grab the latest one and then use it to run the test suite. During times of heavy GitHub Actions traffic, there can be a bit of a wait before a new token is generated however, you only really need to see this pass once before merging a PR so I think this is acceptable.

In order to get this to work, I've added an `--identity-token` flag to the `sigstore-cli` similar to what we have in `sigstore-python`, `cosign`, etc.