### PR TITLE
Handle parse exceptions on raw rekor entry

### DIFF
--- a/fuzzing/src/main/java/fuzzing/FulcioCertificateVerifierFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/FulcioCertificateVerifierFuzzer.java
@@ -41,7 +41,7 @@ public class FulcioCertificateVerifierFuzzer {
 
     try {
       FulcioCertificateVerifier verifier = new FulcioCertificateVerifier();
-      List list =
+      List<CertificateIdentity> list =
           List.of(
               CertificateIdentity.builder().subjectAlternativeName(string).issuer(string).build(),
               CertificateIdentity.builder().subjectAlternativeName(string).issuer(string).build());

--- a/fuzzing/src/main/java/fuzzing/KeylessSigningFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/KeylessSigningFuzzer.java
@@ -21,6 +21,7 @@ import dev.sigstore.KeylessSigner;
 import dev.sigstore.fulcio.client.FulcioVerificationException;
 import dev.sigstore.fulcio.client.UnsupportedAlgorithmException;
 import dev.sigstore.oidc.client.OidcException;
+import dev.sigstore.rekor.client.RekorParseException;
 import dev.sigstore.rekor.client.RekorVerificationException;
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
@@ -51,7 +52,8 @@ public class KeylessSigningFuzzer {
         | RekorVerificationException
         | OidcException
         | UnsupportedAlgorithmException
-        | FulcioVerificationException e) {
+        | FulcioVerificationException
+        | RekorParseException e) {
       // known exceptions
     }
   }

--- a/fuzzing/src/main/java/fuzzing/RekorTypesFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/RekorTypesFuzzer.java
@@ -17,6 +17,7 @@ package fuzzing;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import dev.sigstore.rekor.client.RekorEntry;
+import dev.sigstore.rekor.client.RekorParseException;
 import dev.sigstore.rekor.client.RekorResponse;
 import dev.sigstore.rekor.client.RekorTypeException;
 import dev.sigstore.rekor.client.RekorTypes;
@@ -34,7 +35,7 @@ public class RekorTypesFuzzer {
       RekorEntry entry = RekorResponse.newRekorResponse(uri, string).getEntry();
 
       RekorTypes.getHashedRekord(entry);
-    } catch (URISyntaxException | RekorTypeException e) {
+    } catch (URISyntaxException | RekorTypeException | RekorParseException e) {
       // Known exception
     }
   }

--- a/fuzzing/src/main/java/fuzzing/RekorVerifierFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/RekorVerifierFuzzer.java
@@ -17,6 +17,7 @@ package fuzzing;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import dev.sigstore.rekor.client.RekorEntry;
+import dev.sigstore.rekor.client.RekorParseException;
 import dev.sigstore.rekor.client.RekorResponse;
 import dev.sigstore.rekor.client.RekorVerificationException;
 import dev.sigstore.rekor.client.RekorVerifier;
@@ -45,6 +46,7 @@ public class RekorVerifierFuzzer {
         | InvalidKeySpecException
         | NoSuchAlgorithmException
         | IOException
+        | RekorParseException
         | RekorVerificationException e) {
       // Known exception
     }

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -250,7 +250,8 @@ public class KeylessSigner implements AutoCloseable {
   public List<KeylessSignature> sign(List<byte[]> artifactDigests)
       throws OidcException, NoSuchAlgorithmException, SignatureException, InvalidKeyException,
           UnsupportedAlgorithmException, CertificateException, IOException,
-          FulcioVerificationException, RekorVerificationException, InterruptedException {
+          FulcioVerificationException, RekorVerificationException, InterruptedException,
+          RekorParseException {
 
     if (artifactDigests.size() == 0) {
       throw new IllegalArgumentException("Require one or more digests");
@@ -349,7 +350,7 @@ public class KeylessSigner implements AutoCloseable {
   public KeylessSignature sign(byte[] artifactDigest)
       throws FulcioVerificationException, RekorVerificationException, UnsupportedAlgorithmException,
           CertificateException, NoSuchAlgorithmException, SignatureException, IOException,
-          OidcException, InvalidKeyException, InterruptedException {
+          OidcException, InvalidKeyException, InterruptedException, RekorParseException {
     return sign(List.of(artifactDigest)).get(0);
   }
 
@@ -363,7 +364,7 @@ public class KeylessSigner implements AutoCloseable {
   public Map<Path, KeylessSignature> signFiles(List<Path> artifacts)
       throws FulcioVerificationException, RekorVerificationException, UnsupportedAlgorithmException,
           CertificateException, NoSuchAlgorithmException, SignatureException, IOException,
-          OidcException, InvalidKeyException, InterruptedException {
+          OidcException, InvalidKeyException, InterruptedException, RekorParseException {
     if (artifacts.size() == 0) {
       throw new IllegalArgumentException("Require one or more paths");
     }
@@ -390,7 +391,7 @@ public class KeylessSigner implements AutoCloseable {
   public KeylessSignature signFile(Path artifact)
       throws FulcioVerificationException, RekorVerificationException, UnsupportedAlgorithmException,
           CertificateException, NoSuchAlgorithmException, SignatureException, IOException,
-          OidcException, InvalidKeyException, InterruptedException {
+          OidcException, InvalidKeyException, InterruptedException, RekorParseException {
     return signFiles(List.of(artifact)).get(artifact);
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
@@ -280,8 +280,8 @@ public class KeylessVerifier {
       if (rekorEntry.isEmpty()) {
         throw new KeylessVerificationException("Rekor entry was not found");
       }
-    } catch (IOException ioe) {
-      throw new KeylessVerificationException("Could not retreive rekor entry", ioe);
+    } catch (IOException | RekorParseException e) {
+      throw new KeylessVerificationException("Could not retrieve rekor entry", e);
     }
     return rekorEntry.get();
   }

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient.java
@@ -73,7 +73,8 @@ public class RekorClient {
    * @param hashedRekordRequest the request to send to rekor
    * @return a {@link RekorResponse} with information about the log entry
    */
-  public RekorResponse putEntry(HashedRekordRequest hashedRekordRequest) throws IOException {
+  public RekorResponse putEntry(HashedRekordRequest hashedRekordRequest)
+      throws IOException, RekorParseException {
     URI rekorPutEndpoint = serverUrl.resolve(REKOR_ENTRIES_PATH);
 
     HttpRequest req =
@@ -100,11 +101,12 @@ public class RekorClient {
     return RekorResponse.newRekorResponse(rekorEntryUri, entry);
   }
 
-  public Optional<RekorEntry> getEntry(HashedRekordRequest hashedRekordRequest) throws IOException {
+  public Optional<RekorEntry> getEntry(HashedRekordRequest hashedRekordRequest)
+      throws IOException, RekorParseException {
     return getEntry(hashedRekordRequest.computeUUID());
   }
 
-  public Optional<RekorEntry> getEntry(String UUID) throws IOException {
+  public Optional<RekorEntry> getEntry(String UUID) throws IOException, RekorParseException {
     URI getEntryURI = serverUrl.resolve(REKOR_ENTRIES_PATH + "/" + UUID);
     HttpRequest req =
         HttpClients.newRequestFactory(httpParams).buildGetRequest(new GenericUrl(getEntryURI));

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorParseException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorParseException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.rekor.client;
+
+public class RekorParseException extends Exception {
+  public RekorParseException(String message) {
+    super(message);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
@@ -51,12 +51,17 @@ public interface RekorResponse {
    * @param entryLocation the entry location from the http headers
    * @param rawResponse the body of the rekor response as a string
    * @return an immutable {@link RekorResponse} instance
+   * @throws RekorParseException if the rawResponse doesn't parse directly to a single rekor entry
    */
-  static RekorResponse newRekorResponse(URI entryLocation, String rawResponse) {
+  static RekorResponse newRekorResponse(URI entryLocation, String rawResponse)
+      throws RekorParseException {
     var type = new TypeToken<Map<String, RekorEntry>>() {}.getType();
     Map<String, RekorEntry> entryMap = GSON.get().fromJson(rawResponse, type);
+    if (entryMap == null) {
+      throw new RekorParseException("Expecting a single rekor entry in response but found none");
+    }
     if (entryMap.size() != 1) {
-      throw new IllegalArgumentException(
+      throw new RekorParseException(
           "Expecting a single rekor entry in response but found: " + entryMap.size());
     }
     var entry = entryMap.entrySet().iterator().next();

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessSignerTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessSignerTest.java
@@ -16,21 +16,10 @@
 package dev.sigstore;
 
 import com.google.common.hash.Hashing;
-import dev.sigstore.fulcio.client.FulcioVerificationException;
-import dev.sigstore.fulcio.client.UnsupportedAlgorithmException;
-import dev.sigstore.oidc.client.OidcException;
-import dev.sigstore.rekor.client.RekorVerificationException;
 import dev.sigstore.testing.matchers.ByteArrayListMatcher;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SignatureException;
-import java.security.cert.CertificateException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -55,11 +44,7 @@ public class KeylessSignerTest {
   public static KeylessSigner signer;
 
   @BeforeAll
-  public static void setup()
-      throws IOException, InvalidAlgorithmParameterException, CertificateException,
-          InvalidKeySpecException, NoSuchAlgorithmException, FulcioVerificationException,
-          RekorVerificationException, UnsupportedAlgorithmException, SignatureException,
-          OidcException, InvalidKeyException, InterruptedException {
+  public static void setup() throws Exception {
     artifactHashes = new ArrayList<>();
     artifacts = new ArrayList<>();
     signingResults = new ArrayList<>();

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
@@ -111,9 +111,7 @@ public class RekorClientTest {
   }
 
   @Test
-  public void searchEntries_moreThanOneResult_email()
-      throws IOException, CertificateException, NoSuchAlgorithmException, SignatureException,
-          URISyntaxException, InvalidKeyException, OperatorCreationException {
+  public void searchEntries_moreThanOneResult_email() throws Exception {
     var newRekordRequest = createdRekorRequest();
     var newRekordRequest2 = createdRekorRequest();
     client.putEntry(newRekordRequest);
@@ -165,7 +163,7 @@ public class RekorClientTest {
   }
 
   @Test
-  public void getEntry_entryDoesntExist() throws IOException {
+  public void getEntry_entryDoesntExist() throws Exception {
     Optional<RekorEntry> entry =
         client.getEntry(
             "a8d2b213aa7efc1b2c9ccfa2fa647d00b34c63972e04e90276b5c31e0f317afd"); // I made this up

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorTypesTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorTypesTest.java
@@ -16,16 +16,14 @@
 package dev.sigstore.rekor.client;
 
 import com.google.common.io.Resources;
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RekorTypesTest {
 
-  private RekorEntry fromResource(String path) throws IOException, URISyntaxException {
+  private RekorEntry fromResource(String path) throws Exception {
     var rekorResponse = Resources.toString(Resources.getResource(path), StandardCharsets.UTF_8);
 
     return RekorResponse.newRekorResponse(new URI("https://not.used.com"), rekorResponse)


### PR DESCRIPTION
Initially started off just handling the null map that the fuzzer produced, but I think really this should be a checked exception with the system surfacing it to anyone who needs to discover that rekor is providing bad responses.