### PR TITLE
Fix key fuzzer for more coverage

### DIFF
--- a/fuzzing/src/main/java/fuzzing/KeysFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/KeysFuzzer.java
@@ -36,6 +36,10 @@ public class KeysFuzzer {
       }
     } catch (IOException | InvalidKeySpecException | NoSuchAlgorithmException e) {
       // known exceptions
+    } catch (RuntimeException e) {
+      if (!e.toString().contains("not currently supported")) {
+        throw e;
+      }
     }
   }
 }

--- a/fuzzing/src/main/java/fuzzing/KeysFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/KeysFuzzer.java
@@ -26,10 +26,14 @@ public class KeysFuzzer {
     try {
       String[] schemes = {"rsassa-pss-sha256", "ed25519", "ecdsa-sha2-nistp256"};
       String scheme = data.pickValue(schemes);
+      Boolean choice = data.consumeBoolean();
       byte[] byteArray = data.consumeRemainingAsBytes();
 
-      Keys.parsePublicKey(byteArray);
-      Keys.constructTufPublicKey(byteArray, scheme);
+      if (choice) {
+        Keys.parsePublicKey(byteArray);
+      } else {
+        Keys.constructTufPublicKey(byteArray, scheme);
+      }
     } catch (IOException | InvalidKeySpecException | NoSuchAlgorithmException e) {
       // known exceptions
     }

--- a/fuzzing/src/main/java/fuzzing/KeysParsingFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/KeysParsingFuzzer.java
@@ -21,25 +21,14 @@ import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
-public class KeysFuzzer {
+public class KeysParsingFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      String[] schemes = {"rsassa-pss-sha256", "ed25519", "ecdsa-sha2-nistp256"};
-      String scheme = data.pickValue(schemes);
-      Boolean choice = data.consumeBoolean();
       byte[] byteArray = data.consumeRemainingAsBytes();
 
-      if (choice) {
-        Keys.parsePublicKey(byteArray);
-      } else {
-        Keys.constructTufPublicKey(byteArray, scheme);
-      }
+      Keys.parsePublicKey(byteArray);
     } catch (IOException | InvalidKeySpecException | NoSuchAlgorithmException e) {
       // known exceptions
-    } catch (RuntimeException e) {
-      if (!e.toString().contains("not currently supported")) {
-        throw e;
-      }
     }
   }
 }

--- a/fuzzing/src/main/java/fuzzing/TufKeysFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/TufKeysFuzzer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fuzzing;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import dev.sigstore.encryption.Keys;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+public class TufKeysFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    try {
+      String[] schemes = {"rsassa-pss-sha256", "ed25519", "ecdsa-sha2-nistp256"};
+      String scheme = data.pickValue(schemes);
+      byte[] byteArray = data.consumeRemainingAsBytes();
+
+      Keys.constructTufPublicKey(byteArray, scheme);
+    } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+      // known exceptions
+    } catch (RuntimeException e) {
+      if (!e.toString().contains("not currently supported")) {
+        throw e;
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Currently, the Keys.constructTufPublicKey method will not be called if Keys.parsePublicKey throws an exception. This PR changes the logic of KeysFuzzer by separating the two method call into two separate fuzzers.
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
