### PR TITLE
use base google-http-client-bom

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     compileOnly("org.immutables:value-annotations:2.9.3")
     annotationProcessor("org.immutables:value:2.9.3")
 
-    implementation(platform("com.google.cloud:libraries-bom:26.17.0"))
+    implementation(platform("com.google.http-client:google-http-client-bom:1.42.3"))
     implementation("com.google.http-client:google-http-client-apache-v2")
     implementation("com.google.http-client:google-http-client-gson")
 


### PR DESCRIPTION
#### Summary
Using `com.google.cloud:libraries-bom` imports many other nested BOMs, even if they are not used at the end: the fact is that it confuses Maven dependencyManagement import on generated pom.xml
Going straight to `com.google.http-client:google-http-client-bom` is just more efficient and clear

#### Release Note

#### Documentation
