### PR TITLE
chore: use snapshot version unless user asks producing a release version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,11 +6,9 @@ plugins {
     `embedded-kotlin` apply false
 }
 
-val buildVersion = "${findProperty("version")}${releaseParams.snapshotSuffix}"
+version = "${findProperty("version")}${releaseParams.snapshotSuffix}"
 
-println("Building Sigstore Java $buildVersion")
-
-val isReleaseVersion = rootProject.releaseParams.release.get()
+println("Building Sigstore Java $version")
 
 releaseParams {
     tlp.set("sigstore-java")
@@ -33,5 +31,5 @@ releaseParams {
 }
 
 allprojects {
-    version = project.findProperty("version") as? String ?: rootProject.version
+    version = rootProject.version
 }


### PR DESCRIPTION
#### Summary

Add `-SNAPSHOT` by default, so the default builds do not collide with the releases.
Release version can be triggered with `-Prelease`.

Previously, `pom.xml` included non-snapshot versions always

#### Release Note

NONE

#### Documentation

NONE
