### PR TITLE
test: display problematic rawResponse in newRekorResponse failures

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/json/GsonByteArrayAdapter.java
+++ b/sigstore-java/src/main/java/dev/sigstore/json/GsonByteArrayAdapter.java
@@ -27,7 +27,7 @@ import java.util.Base64;
 class GsonByteArrayAdapter extends TypeAdapter<byte[]> {
   @Override
   public void write(JsonWriter out, byte[] value) throws IOException {
-    out.value(new String(Base64.getEncoder().encodeToString(value)));
+    out.value(Base64.getEncoder().encodeToString(value));
   }
 
   @Override

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
@@ -17,7 +17,8 @@ package dev.sigstore.rekor.client;
 
 import static dev.sigstore.json.GsonSupplier.GSON;
 
-import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 import java.net.URI;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -55,8 +56,12 @@ public interface RekorResponse {
    */
   static RekorResponse newRekorResponse(URI entryLocation, String rawResponse)
       throws RekorParseException {
-    var type = new TypeToken<Map<String, RekorEntry>>() {}.getType();
-    Map<String, RekorEntry> entryMap = GSON.get().fromJson(rawResponse, type);
+    Map<String, RekorEntry> entryMap;
+    try {
+      entryMap = GSON.get().fromJson(rawResponse, new TypeToken<>() {});
+    } catch (JsonSyntaxException e) {
+      throw new RekorParseException("Unable to parse rekor response " + rawResponse, e);
+    }
     if (entryMap == null) {
       throw new RekorParseException("Expecting a single rekor entry in response but found none");
     }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -18,6 +18,7 @@ package dev.sigstore.tuf;
 import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonSyntaxException;
 import dev.sigstore.tuf.model.*;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -109,7 +110,12 @@ public class FileSystemTufStore implements MutableTufStore {
     if (!roleFile.toFile().exists()) {
       return Optional.empty();
     }
-    return Optional.of(GSON.get().fromJson(Files.readString(roleFile), tClass));
+    String roleJsonString = Files.readString(roleFile);
+    try {
+      return Optional.of(GSON.get().fromJson(roleJsonString, tClass));
+    } catch (JsonSyntaxException e) {
+      throw new MetadataFileParseException(roleFile, e);
+    }
   }
 
   <T extends SignedTufMeta<?>> void storeRole(T role) throws IOException {

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetadataFileParseException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetadataFileParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Sigstore Authors.
+ * Copyright 2022 The Sigstore Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.sigstore.rekor.client;
+package dev.sigstore.tuf;
 
-public class RekorParseException extends Exception {
-  public RekorParseException(String message) {
-    super(message);
+import java.nio.file.Path;
+import java.util.Locale;
+
+/** Thrown when the metadata has not been signed by enough of the allowed keys. */
+public class MetadataFileParseException extends TufException {
+  private final Path path;
+
+  public MetadataFileParseException(Path path, Throwable cause) {
+    super(
+        String.format(
+            Locale.ROOT,
+            "Unable to parse TUF metadata file %s",
+            path),
+        cause);
+    this.path = path;
   }
 
-  public RekorParseException(String message, Throwable cause) {
-    super(message, cause);
+  public Path getPath() {
+    return path;
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TufException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TufException.java
@@ -17,6 +17,10 @@ package dev.sigstore.tuf;
 
 /** Catch-all TUF Exception. */
 public class TufException extends RuntimeException {
+  public TufException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
   public TufException(String message) {
     super(message);
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -19,6 +19,7 @@ import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
+import com.google.gson.JsonSyntaxException;
 import dev.sigstore.encryption.Keys;
 import dev.sigstore.encryption.signers.Verifiers;
 import dev.sigstore.tuf.model.*;
@@ -106,7 +107,12 @@ public class Updater {
     if (localRoot.isPresent()) {
       trustedRoot = localRoot.get();
     } else {
-      trustedRoot = GSON.get().fromJson(Files.readString(trustedRootPath), Root.class);
+      String trustedRootJson = Files.readString(trustedRootPath);
+      try {
+        trustedRoot = GSON.get().fromJson(trustedRootJson, Root.class);
+      } catch (JsonSyntaxException e) {
+        throw new MetadataFileParseException(trustedRootPath, e);
+      }
     }
     int baseVersion = trustedRoot.getSignedMeta().getVersion();
     int nextVersion = baseVersion + 1;

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -18,6 +18,7 @@ package dev.sigstore;
 import com.google.common.hash.Hashing;
 import dev.sigstore.bundle.BundleFactory;
 import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.rekor.client.RekorParseException;
 import dev.sigstore.rekor.client.RekorTypeException;
 import dev.sigstore.rekor.client.RekorTypes;
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists;
@@ -92,7 +93,7 @@ public class KeylessTest {
   }
 
   private void verifySigningResult(List<KeylessSignature> results)
-      throws IOException, RekorTypeException {
+      throws IOException, RekorTypeException, RekorParseException {
 
     Assertions.assertEquals(artifactDigests.size(), results.size());
 

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
@@ -76,7 +76,7 @@ public class RekorClientTest {
   // TODO(patrick@chainguard.dev): don't use data from prod, create the data as part of the test
   // setup in staging.
   @Test
-  public void searchEntries_nullParams() throws IOException {
+  public void searchEntries_nullParams() throws IOException, RekorParseException {
     assertEquals(ImmutableList.of(), client.searchEntry(null, null, null, null));
   }
 
@@ -122,7 +122,7 @@ public class RekorClientTest {
   }
 
   @Test
-  public void searchEntries_zeroResults() throws IOException {
+  public void searchEntries_zeroResults() throws IOException, RekorParseException {
     assertTrue(
         client
             .searchEntry(


### PR DESCRIPTION
#### Summary

We have `RekorParseException`, and it seems whe should wrap `JsonParseException` with our own `RekorParseException`.
It looks like Gson is more like implementation details, so we should not expose `JsonParseException` in our APIs.

#### Release Note

NONE

#### Documentation

NONE