### PR TITLE
Updates before applying tuf to fulcio client

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/Certificates.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/certificates/Certificates.java
@@ -16,6 +16,7 @@
 package dev.sigstore.encryption.certificates;
 
 import com.google.api.client.util.PemReader;
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
@@ -134,5 +135,17 @@ public class Certificates {
   public static CertPath toCertPath(Certificate certificate) throws CertificateException {
     CertificateFactory cf = CertificateFactory.getInstance("X.509");
     return cf.generateCertPath(Collections.singletonList(certificate));
+  }
+
+  /** Appends an X509Certificate to a {@link CertPath} as a leaf. */
+  public static CertPath appendCertPath(CertPath root, Certificate certificate)
+      throws CertificateException {
+    CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    List<Certificate> certs =
+        ImmutableList.<Certificate>builder()
+            .add(certificate)
+            .addAll(root.getCertificates())
+            .build();
+    return cf.generateCertPath(certs);
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/http/GrpcChannels.java
+++ b/sigstore-java/src/main/java/dev/sigstore/http/GrpcChannels.java
@@ -39,4 +39,23 @@ public class GrpcChannels {
     }
     return channelBuilder.build();
   }
+
+  /**
+   * Create a new managed channel, this may be reused across multiple requests to a host, and must
+   * be closed when finished.
+   *
+   * @param serverUrl the host to connect to
+   * @param httpParams the http configuration
+   * @return a reusable grpc channel
+   */
+  public static ManagedChannel newManagedChannel(String serverUrl, HttpParams httpParams) {
+    var channelBuilder =
+        ManagedChannelBuilder.forTarget(serverUrl)
+            .userAgent(httpParams.getUserAgent())
+            .keepAliveTimeout(httpParams.getTimeout(), TimeUnit.SECONDS);
+    if (httpParams.getAllowInsecureConnections()) {
+      channelBuilder.usePlaintext();
+    }
+    return channelBuilder.build();
+  }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/CertificateAuthorities.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/CertificateAuthorities.java
@@ -16,6 +16,7 @@
 package dev.sigstore.trustroot;
 
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.immutables.value.Value;
@@ -26,7 +27,7 @@ import org.immutables.value.Value.Immutable;
 @Value.Style(
     depluralize = true,
     depluralizeDictionary = {"certificateAuthority:certificateAuthorities"})
-public abstract class CertificateAuthorities {
+public abstract class CertificateAuthorities implements Iterable<CertificateAuthority> {
 
   public abstract List<CertificateAuthority> getCertificateAuthorities();
 
@@ -73,5 +74,10 @@ public abstract class CertificateAuthorities {
           "Trust root contains multiple current certificate authorities (" + current.size() + ")");
     }
     return current.get(0);
+  }
+
+  @Override
+  public Iterator<CertificateAuthority> iterator() {
+    return getCertificateAuthorities().iterator();
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/Subject.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/Subject.java
@@ -19,7 +19,7 @@ import dev.sigstore.proto.common.v1.DistinguishedName;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
-interface Subject {
+public interface Subject {
   String getOrganization();
 
   String getCommonName();

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLogs.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLogs.java
@@ -17,6 +17,7 @@ package dev.sigstore.trustroot;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -26,7 +27,7 @@ import org.immutables.value.Value.Immutable;
 
 @Immutable
 @Value.Style(depluralize = true)
-public abstract class TransparencyLogs {
+public abstract class TransparencyLogs implements Iterable<TransparencyLog> {
 
   public abstract List<TransparencyLog> getTransparencyLogs();
 
@@ -63,5 +64,10 @@ public abstract class TransparencyLogs {
             tl ->
                 tl.getPublicKey().getValidFor().getEnd().orElse(Instant.now()).compareTo(time) >= 0)
         .findAny();
+  }
+
+  @Override
+  public Iterator<TransparencyLog> iterator() {
+    return getTransparencyLogs().iterator();
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/encryption/certificates/CertificatesTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/encryption/certificates/CertificatesTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 public class CertificatesTest {
   static final String CERT_CHAIN = "dev/sigstore/samples/certs/cert.pem";
   static final String CERT = "dev/sigstore/samples/certs/cert-single.pem";
+  static final String CERT_GH = "dev/sigstore/samples/certs/cert-githuboidc.pem";
 
   @Test
   public void testCertificateTranslation() throws IOException, CertificateException {
@@ -129,5 +130,20 @@ public class CertificatesTest {
     var certPath = Certificates.toCertPath(cert);
     Assertions.assertEquals(1, certPath.getCertificates().size());
     Assertions.assertEquals(cert, certPath.getCertificates().get(0));
+  }
+
+  @Test
+  public void appendCertPath() throws Exception {
+    var certPath =
+        Certificates.fromPemChain(Resources.toByteArray(Resources.getResource(CERT_CHAIN)));
+    var cert = Certificates.fromPem(Resources.toByteArray(Resources.getResource(CERT_GH)));
+
+    Assertions.assertEquals(2, certPath.getCertificates().size());
+    var appended = Certificates.appendCertPath(certPath, cert);
+
+    Assertions.assertEquals(3, appended.getCertificates().size());
+    Assertions.assertEquals(cert, appended.getCertificates().get(0));
+    Assertions.assertEquals(certPath.getCertificates().get(0), appended.getCertificates().get(1));
+    Assertions.assertEquals(certPath.getCertificates().get(1), appended.getCertificates().get(2));
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
@@ -100,7 +100,7 @@ class SigstoreTrustedRootTest {
         Base64.toBase64String(tlog.getLogId().getKeyId()));
     assertEquals(
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==",
-        Base64.toBase64String(PublicKey.toJavaPublicKey(tlog.getPublicKey()).getEncoded()));
+        Base64.toBase64String(tlog.getPublicKey().toJavaPublicKey().getEncoded()));
 
     var oldCTLog = trustRoot.getCTLogs().all().get(0);
     assertEquals("https://ctfe.sigstore.dev/test", oldCTLog.getBaseUrl().toString());
@@ -116,7 +116,7 @@ class SigstoreTrustedRootTest {
         Base64.toBase64String(oldCTLog.getLogId().getKeyId()));
     assertEquals(
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
-        Base64.toBase64String(PublicKey.toJavaPublicKey(oldCTLog.getPublicKey()).getEncoded()));
+        Base64.toBase64String(oldCTLog.getPublicKey().toJavaPublicKey().getEncoded()));
 
     var currCTLog = trustRoot.getCTLogs().all().get(1);
     assertEquals("https://ctfe.sigstore.dev/2022", currCTLog.getBaseUrl().toString());
@@ -130,7 +130,7 @@ class SigstoreTrustedRootTest {
         Base64.toBase64String(currCTLog.getLogId().getKeyId()));
     assertEquals(
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
-        Base64.toBase64String(PublicKey.toJavaPublicKey(currCTLog.getPublicKey()).getEncoded()));
+        Base64.toBase64String(currCTLog.getPublicKey().toJavaPublicKey().getEncoded()));
   }
 
   @Test


### PR DESCRIPTION
- iterate over collection types
- allow appending to certpaths
- managed channels from string targets
- create trust roots directly on CA object
- private key conversion
