### PR TITLE
configure fulcio (v2 for now) with trustroot

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioClient2.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioClient2.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.fulcio.client;
+
+import static dev.sigstore.fulcio.v2.SigningCertificate.CertificateCase.SIGNED_CERTIFICATE_DETACHED_SCT;
+
+import com.google.protobuf.ByteString;
+import dev.sigstore.fulcio.v2.CAGrpc;
+import dev.sigstore.fulcio.v2.CreateSigningCertificateRequest;
+import dev.sigstore.fulcio.v2.Credentials;
+import dev.sigstore.fulcio.v2.PublicKey;
+import dev.sigstore.fulcio.v2.PublicKeyRequest;
+import dev.sigstore.http.GrpcChannels;
+import dev.sigstore.http.HttpParams;
+import dev.sigstore.http.ImmutableHttpParams;
+import dev.sigstore.trustroot.CertificateAuthority;
+import java.security.cert.CertificateException;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+/** A client to communicate with a fulcio service instance over gRPC. */
+public class FulcioClient2 {
+
+  private final HttpParams httpParams;
+  private final CertificateAuthority certificateAuthority;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private FulcioClient2(HttpParams httpParams, CertificateAuthority certificateAuthority) {
+    this.certificateAuthority = certificateAuthority;
+    this.httpParams = httpParams;
+  }
+
+  public static class Builder {
+    private CertificateAuthority certificateAuthority;
+    private HttpParams httpParams = ImmutableHttpParams.builder().build();
+
+    private Builder() {}
+
+    /** Configure the http properties, see {@link HttpParams}. */
+    public Builder setHttpParams(HttpParams httpParams) {
+      this.httpParams = httpParams;
+      return this;
+    }
+
+    /** The remote fulcio instance. */
+    public Builder setCertificateAuthority(CertificateAuthority certificateAuthority) {
+      this.certificateAuthority = certificateAuthority;
+      return this;
+    }
+
+    public FulcioClient2 build() {
+      return new FulcioClient2(httpParams, certificateAuthority);
+    }
+  }
+
+  /**
+   * Request a signing certificate from fulcio.
+   *
+   * @param request certificate request parameters
+   * @return a {@link SigningCertificate} from fulcio
+   */
+  public SigningCertificate signingCertificate(CertificateRequest request)
+      throws InterruptedException, CertificateException {
+    if (!certificateAuthority.isCurrent()) {
+      throw new RuntimeException(
+          "Certificate Authority '" + certificateAuthority.getUri() + "' is not current");
+    }
+    // TODO: 1. If we want to reduce the cost of creating channels/connections, we could try
+    // to make a new connection once per batch of fulcio requests, but we're not really
+    // at that point yet.
+    // TODO: 2. getUri().getAuthority() is potentially prone to error if we don't get a good URI
+    var channel =
+        GrpcChannels.newManagedChannel(certificateAuthority.getUri().getAuthority(), httpParams);
+
+    try {
+      var client = CAGrpc.newBlockingStub(channel);
+      var credentials = Credentials.newBuilder().setOidcIdentityToken(request.getIdToken()).build();
+
+      String pemEncodedPublicKey =
+          "-----BEGIN PUBLIC KEY-----\n"
+              + Base64.getEncoder().encodeToString(request.getPublicKey().getEncoded())
+              + "\n-----END PUBLIC KEY-----";
+      var publicKeyRequest =
+          PublicKeyRequest.newBuilder()
+              .setPublicKey(
+                  PublicKey.newBuilder()
+                      .setAlgorithm(request.getPublicKeyAlgorithm())
+                      .setContent(pemEncodedPublicKey)
+                      .build())
+              .setProofOfPossession(ByteString.copyFrom(request.getProofOfPossession()))
+              .build();
+      var req =
+          CreateSigningCertificateRequest.newBuilder()
+              .setCredentials(credentials)
+              .setPublicKeyRequest(publicKeyRequest)
+              .build();
+
+      var certs =
+          client
+              .withDeadlineAfter(httpParams.getTimeout(), TimeUnit.SECONDS)
+              .createSigningCertificate(req);
+
+      if (certs.getCertificateCase() == SIGNED_CERTIFICATE_DETACHED_SCT) {
+        throw new CertificateException("Detached SCTs are not supported");
+      }
+      return SigningCertificate.newSigningCertificate(certs.getSignedCertificateEmbeddedSct());
+    } finally {
+      channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier2.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier2.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.fulcio.client;
+
+import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.encryption.certificates.transparency.CTLogInfo;
+import dev.sigstore.encryption.certificates.transparency.CTVerificationResult;
+import dev.sigstore.encryption.certificates.transparency.CTVerifier;
+import dev.sigstore.trustroot.CertificateAuthorities;
+import dev.sigstore.trustroot.SigstoreTrustedRoot;
+import dev.sigstore.trustroot.TransparencyLogs;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertPathValidator;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.PKIXParameters;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Verifier for fulcio {@link SigningCertificate}. */
+public class FulcioVerifier2 {
+  private final CertificateAuthorities cas;
+  private final TransparencyLogs ctLogs;
+  private final CTVerifier ctVerifier;
+
+  public static FulcioVerifier2 newFulcioVerifier(SigstoreTrustedRoot trustRoot)
+      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
+          NoSuchAlgorithmException {
+    return newFulcioVerifier(trustRoot.getCAs(), trustRoot.getCTLogs());
+  }
+
+  public static FulcioVerifier2 newFulcioVerifier(
+      CertificateAuthorities cas, TransparencyLogs ctLogs)
+      throws InvalidKeySpecException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
+          CertificateException {
+    List<CTLogInfo> logs = new ArrayList<>();
+    for (var ctLog : ctLogs.all()) {
+      logs.add(
+          new CTLogInfo(
+              ctLog.getPublicKey().toJavaPublicKey(), "CT Log", ctLog.getBaseUrl().toString()));
+    }
+    var verifier =
+        new CTVerifier(
+            logId ->
+                logs.stream()
+                    .filter(ctLogInfo -> Arrays.equals(ctLogInfo.getID(), logId))
+                    .findFirst()
+                    .orElse(null));
+
+    // check to see if we can use all fulcio roots (this is a bit eager)
+    for (var ca : cas.all()) {
+      ca.asTrustAnchor();
+    }
+
+    return new FulcioVerifier2(cas, ctLogs, verifier);
+  }
+
+  private FulcioVerifier2(
+      CertificateAuthorities cas, TransparencyLogs ctLogs, CTVerifier ctVerifier) {
+    this.cas = cas;
+    this.ctLogs = ctLogs;
+    this.ctVerifier = ctVerifier;
+  }
+
+  /**
+   * Verify that an SCT associated with a Singing Certificate is valid and signed by the configured
+   * CT-log public key.
+   *
+   * @param signingCertificate containing the SCT metadata to verify
+   * @throws FulcioVerificationException if verification fails for any reason
+   */
+  public void verifySct(SigningCertificate signingCertificate) throws FulcioVerificationException {
+    if (ctLogs.size() == 0) {
+      throw new FulcioVerificationException("No ct logs were provided to verifier");
+    }
+
+    if (signingCertificate.getDetachedSct().isPresent()) {
+      throw new FulcioVerificationException(
+          "Detached SCTs are not supported for validating certificates");
+    } else if (signingCertificate.getEmbeddedSct().isPresent()) {
+      verifyEmbeddedScts(signingCertificate);
+    } else {
+      throw new FulcioVerificationException("No valid SCTs were found during verification");
+    }
+  }
+
+  private void verifyEmbeddedScts(SigningCertificate signingCertificate)
+      throws FulcioVerificationException {
+    var certs = signingCertificate.getCertificates();
+    CTVerificationResult result;
+    try {
+      // even though we're sending the whole chain, this method only checks SCTs on the leaf cert
+      result = ctVerifier.verifySignedCertificateTimestamps(certs, null, null);
+    } catch (CertificateEncodingException cee) {
+      throw new FulcioVerificationException(
+          "Certificates could not be parsed during SCT verification");
+    }
+
+    // these are technically valid, but we have the additional constraint of sigstore's trustroot
+    // providing a validity period for logs, so make sure all SCTs were signed by a log during
+    // that log's validity period
+    for (var validSct : result.getValidSCTs()) {
+      var sct = validSct.sct;
+
+      var logId = sct.getLogID();
+      var entryTime = Instant.ofEpochMilli(sct.getTimestamp());
+
+      var ctLog = ctLogs.find(logId, entryTime);
+      if (ctLog.isPresent()) {
+        // TODO: currently we only require one valid SCT, but maybe this should be configurable?
+        // found at least one valid sct with a matching valid log
+        return;
+      }
+    }
+    throw new FulcioVerificationException(
+        "No valid SCTs were found, all("
+            + (result.getValidSCTs().size() + result.getInvalidSCTs().size())
+            + ") SCTs were invalid");
+  }
+
+  /**
+   * Verify that a cert chain is valid and chains up to the trust anchor (fulcio public key)
+   * configured in this validator.
+   *
+   * @param signingCertificate containing the certificate chain
+   * @throws FulcioVerificationException if verification fails for any reason
+   */
+  public void verifyCertChain(SigningCertificate signingCertificate)
+      throws FulcioVerificationException, IOException {
+    CertPathValidator cpv;
+    try {
+      cpv = CertPathValidator.getInstance("PKIX");
+    } catch (NoSuchAlgorithmException e) {
+      //
+      throw new RuntimeException(
+          "No PKIX CertPathValidator, we probably shouldn't be here, but this seems to be a system library error not a program control flow issue",
+          e);
+    }
+
+    var leaf = signingCertificate.getLeafCertificate();
+    var validCAs = cas.find(leaf.getNotBefore().toInstant());
+
+    if (validCAs.size() == 0) {
+      throw new FulcioVerificationException(
+          "No valid Certificate Authorities found when validating certificate");
+    }
+
+    Map<String, String> caVerificationFailure = new LinkedHashMap<>();
+
+    System.out.println(Certificates.toPemString(signingCertificate.getCertPath()));
+
+    for (var ca : validCAs) {
+      PKIXParameters pkixParams;
+      try {
+        pkixParams = new PKIXParameters(Collections.singleton(ca.asTrustAnchor()));
+      } catch (InvalidAlgorithmParameterException | CertificateException e) {
+        throw new RuntimeException(
+            "Can't create PKIX parameters for fulcioRoot. This should have been checked when generating a verifier instance",
+            e);
+      }
+      pkixParams.setRevocationEnabled(false);
+
+      // these certs are only valid for 15 minutes, so find a time in the validity period
+      @SuppressWarnings("JavaUtilDate")
+      Date dateInValidityPeriod =
+          new Date(signingCertificate.getLeafCertificate().getNotBefore().getTime());
+      pkixParams.setDate(dateInValidityPeriod);
+
+      try {
+        // build a cert chain with the root-chain in question and the provided leaf
+        var rebuiltCert =
+            Certificates.appendCertPath(ca.getCertPath(), signingCertificate.getLeafCertificate());
+        // a result is returned here, but we ignore it
+        cpv.validate(rebuiltCert, pkixParams);
+      } catch (CertPathValidatorException
+          | InvalidAlgorithmParameterException
+          | CertificateException ve) {
+        caVerificationFailure.put(ca.getUri().toString(), ve.getMessage());
+        // verification failed
+        continue;
+      }
+      // verification passed so just end this method
+      return;
+    }
+    String errors =
+        caVerificationFailure.entrySet().stream()
+            .map(entry -> entry.getKey() + " (" + entry.getValue() + ")")
+            .collect(Collectors.joining("\n"));
+    throw new FulcioVerificationException("Certificate was not verifiable against CAs\n" + errors);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/SigningCertificate.java
@@ -126,9 +126,17 @@ public class SigningCertificate {
     return GSON.get().fromJson(sctJson, SctJson.class).toSct();
   }
 
-  /** Returns true if the signing certificate constains an SCT embedded in the X509 extensions. */
+  /** Returns true if the signing certificate contains scts embedded in X509 extensions. */
   boolean hasEmbeddedSct() {
     return getLeafCertificate().getExtensionValue(SCT_X509_OID) != null;
+  }
+
+  /**
+   * Returns scts if present, or empty if not. The returned byte array may contain any number of
+   * embedded scts.
+   */
+  Optional<byte[]> getEmbeddedSct() {
+    return Optional.ofNullable(getLeafCertificate().getExtensionValue(SCT_X509_OID));
   }
 
   private static class SctJson {

--- a/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioClient2Test.java
+++ b/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioClient2Test.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.fulcio.client;
+
+import dev.sigstore.encryption.signers.Signers;
+import dev.sigstore.http.ImmutableHttpParams;
+import dev.sigstore.testing.FakeCTLogServer;
+import dev.sigstore.testing.FulcioWrapper;
+import dev.sigstore.testing.MockOAuth2ServerExtension;
+import dev.sigstore.trustroot.CertificateAuthority;
+import dev.sigstore.trustroot.ImmutableCertificateAuthority;
+import dev.sigstore.trustroot.ImmutableValidFor;
+import dev.sigstore.trustroot.Subject;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertPath;
+import java.security.cert.CertificateException;
+import java.time.Instant;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+public class FulcioClient2Test {
+
+  @Test
+  @ExtendWith({FakeCTLogServer.class, MockOAuth2ServerExtension.class, FulcioWrapper.class})
+  public void testSigningCert(
+      MockOAuth2ServerExtension mockOAuthServerExtension, FulcioWrapper fulcioWrapper)
+      throws Exception {
+    var c =
+        FulcioClient2.builder()
+            .setHttpParams(ImmutableHttpParams.builder().allowInsecureConnections(true).build())
+            .setCertificateAuthority(createCA(fulcioWrapper.getGrpcURI2()))
+            .build();
+
+    // create a "subject" and sign it with the oidc server key (signed JWT)
+    var token = mockOAuthServerExtension.getOidcToken().getIdToken();
+    var subject = mockOAuthServerExtension.getOidcToken().getSubjectAlternativeName();
+
+    var signer = Signers.newEcdsaSigner();
+    var signed = signer.sign(subject.getBytes(StandardCharsets.UTF_8));
+
+    // create a certificate request with our public key and our signed "subject"
+    var cReq = CertificateRequest.newCertificateRequest(signer.getPublicKey(), token, signed);
+
+    // ask fulcio for a signing cert
+    var sc = c.signingCertificate(cReq);
+
+    // some pretty basic assertions
+    Assertions.assertTrue(sc.getCertPath().getCertificates().size() > 0);
+    Assertions.assertTrue(sc.hasEmbeddedSct());
+  }
+
+  @Test
+  @ExtendWith({MockOAuth2ServerExtension.class, FulcioWrapper.class})
+  public void testSigningCert_NoSct(
+      MockOAuth2ServerExtension mockOAuthServerExtension, FulcioWrapper fulcioWrapper)
+      throws Exception {
+    var c =
+        FulcioClient2.builder()
+            .setHttpParams(ImmutableHttpParams.builder().allowInsecureConnections(true).build())
+            .setCertificateAuthority(createCA(fulcioWrapper.getGrpcURI2()))
+            .build();
+
+    // create a "subject" and sign it with the oidc server key (signed JWT)
+    var token = mockOAuthServerExtension.getOidcToken().getIdToken();
+    var subject = mockOAuthServerExtension.getOidcToken().getSubjectAlternativeName();
+
+    var signer = Signers.newRsaSigner();
+    var signed = signer.sign(subject.getBytes(StandardCharsets.UTF_8));
+
+    // create a certificate request with our public key and our signed "subject"
+    var cReq = CertificateRequest.newCertificateRequest(signer.getPublicKey(), token, signed);
+
+    // ask fulcio for a signing cert
+    var ex = Assertions.assertThrows(CertificateException.class, () -> c.signingCertificate(cReq));
+    Assertions.assertEquals(ex.getMessage(), "Detached SCTs are not supported");
+  }
+
+  private CertificateAuthority createCA(URI uri) {
+    return ImmutableCertificateAuthority.builder()
+        .uri(uri)
+        .certPath(Mockito.mock(CertPath.class))
+        .subject(Mockito.mock(Subject.class))
+        .validFor(ImmutableValidFor.builder().start(Instant.EPOCH).build())
+        .build();
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioVerifier2Test.java
+++ b/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioVerifier2Test.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.fulcio.client;
+
+import com.google.common.io.Resources;
+import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.encryption.certificates.transparency.SerializationException;
+import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import dev.sigstore.trustroot.ImmutableLogId;
+import dev.sigstore.trustroot.ImmutableTransparencyLog;
+import dev.sigstore.trustroot.ImmutableTransparencyLogs;
+import dev.sigstore.trustroot.SigstoreTrustedRoot;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FulcioVerifier2Test {
+  private static String sctBase64;
+  private static String certs;
+  private static String certs2;
+  private static byte[] fulcioRoot;
+  private static byte[] ctfePub;
+  private static byte[] badCtfePub;
+  private static String certsWithEmbeddedSct;
+
+  private static SigstoreTrustedRoot trustRoot;
+
+  @BeforeAll
+  public static void loadResources() throws IOException {
+    sctBase64 =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/fulcio-response/valid/sct.base64"),
+            StandardCharsets.UTF_8);
+    certs =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/fulcio-response/valid/cert.pem"),
+            StandardCharsets.UTF_8);
+
+    certs2 =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/certs/cert-githuboidc.pem"),
+            StandardCharsets.UTF_8);
+
+    fulcioRoot =
+        Resources.toByteArray(
+            Resources.getResource("dev/sigstore/samples/fulcio-response/valid/fulcio.crt.pem"));
+    ctfePub =
+        Resources.toByteArray(
+            Resources.getResource("dev/sigstore/samples/fulcio-response/valid/ctfe.pub"));
+    badCtfePub =
+        Resources.toByteArray(Resources.getResource("dev/sigstore/samples/keys/test-rsa.pub"));
+
+    certsWithEmbeddedSct =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/fulcio-response/valid/certWithSct.pem"),
+            StandardCharsets.UTF_8);
+  }
+
+  @BeforeAll
+  public static void initTrustRoot() throws IOException, CertificateException {
+    var json =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/trustroot/trusted_root.json"),
+            StandardCharsets.UTF_8);
+    var builder = TrustedRoot.newBuilder();
+    JsonFormat.parser().merge(json, builder);
+
+    trustRoot = SigstoreTrustedRoot.from(builder.build());
+  }
+
+  @Test
+  public void detachedSctNotSupported() throws Exception {
+    var fulcioVerifier = FulcioVerifier2.newFulcioVerifier(trustRoot);
+
+    var signingCertificate = SigningCertificate.newSigningCertificate(certs, sctBase64);
+    var ex =
+        Assertions.assertThrows(
+            FulcioVerificationException.class, () -> fulcioVerifier.verifySct(signingCertificate));
+    Assertions.assertEquals(
+        ex.getMessage(), "Detached SCTs are not supported for validating certificates");
+  }
+
+  @Test
+  public void testVerifySct_nullCtLogKey()
+      throws IOException, SerializationException, CertificateException, InvalidKeySpecException,
+          NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+    var signingCertificate = SigningCertificate.newSigningCertificate(certs, sctBase64);
+    var fulcioVerifier =
+        FulcioVerifier2.newFulcioVerifier(
+            trustRoot.getCAs(),
+            ImmutableTransparencyLogs.builder()
+                .addAllTransparencyLogs(Collections.emptyList())
+                .build());
+
+    try {
+      fulcioVerifier.verifySct(signingCertificate);
+      Assertions.fail();
+    } catch (FulcioVerificationException fve) {
+      Assertions.assertEquals("No ct logs were provided to verifier", fve.getMessage());
+    }
+  }
+
+  @Test
+  public void testVerifySct_noSct() throws Exception {
+    var signingCertificate = SigningCertificate.newSigningCertificate(certs, null);
+    var fulcioVerifier = FulcioVerifier2.newFulcioVerifier(trustRoot);
+
+    try {
+      fulcioVerifier.verifySct(signingCertificate);
+      Assertions.fail();
+    } catch (FulcioVerificationException fve) {
+      Assertions.assertEquals("No valid SCTs were found during verification", fve.getMessage());
+    }
+  }
+
+  @Test
+  public void validSigningCertAndEmbeddedSct() throws Exception {
+    var signingCertificate = SigningCertificate.newSigningCertificate(certsWithEmbeddedSct, null);
+    var fulcioVerifier = FulcioVerifier2.newFulcioVerifier(trustRoot);
+
+    fulcioVerifier.verifyCertChain(signingCertificate);
+    fulcioVerifier.verifySct(signingCertificate);
+  }
+
+  @Test
+  public void invalidEmbeddedSct() throws Exception {
+    var signingCertificate = SigningCertificate.newSigningCertificate(certsWithEmbeddedSct, null);
+    var fulcioVerifier =
+        FulcioVerifier2.newFulcioVerifier(
+            trustRoot.getCAs(),
+            ImmutableTransparencyLogs.builder()
+                .addTransparencyLog(
+                    ImmutableTransparencyLog.builder()
+                        .from(trustRoot.getCTLogs().all().get(0))
+                        .logId(
+                            ImmutableLogId.builder()
+                                .keyId("abcd".getBytes(StandardCharsets.UTF_8))
+                                .build())
+                        .build())
+                .build());
+
+    var fve =
+        Assertions.assertThrows(
+            FulcioVerificationException.class, () -> fulcioVerifier.verifySct(signingCertificate));
+    Assertions.assertEquals("No valid SCTs were found, all(1) SCTs were invalid", fve.getMessage());
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/testing/FulcioWrapper.java
+++ b/sigstore-java/src/test/java/dev/sigstore/testing/FulcioWrapper.java
@@ -44,6 +44,10 @@ public class FulcioWrapper implements BeforeEachCallback, AfterEachCallback, Par
     return URI.create("localhost:5554");
   }
 
+  public URI getGrpcURI2() {
+    return URI.create("http://localhost:5554");
+  }
+
   private Path createConfig(String issuer) throws IOException {
     fulcioConfig = Files.createTempFile("fulcio-config", ".json");
     Files.writeString(


### PR DESCRIPTION
Create v2 of various fulcio utilities so we can plumb the tuf data through. These will eventually replace the original implementations, but we are not ready to do that yet.

Note: v2 fulcio client drops support for detached scts.