### PR TITLE
configure rekor signer (v2 for now) with trustroot

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient2.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient2.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.rekor.client;
+
+import static dev.sigstore.json.GsonSupplier.GSON;
+
+import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseException;
+import com.google.common.base.Preconditions;
+import dev.sigstore.http.HttpClients;
+import dev.sigstore.http.HttpParams;
+import dev.sigstore.http.ImmutableHttpParams;
+import dev.sigstore.trustroot.TransparencyLog;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/** A client to communicate with a rekor service instance. */
+public class RekorClient2 {
+  public static final String REKOR_ENTRIES_PATH = "/api/v1/log/entries";
+  public static final String REKOR_INDEX_SEARCH_PATH = "/api/v1/index/retrieve";
+
+  private final HttpParams httpParams;
+  private final TransparencyLog tlog;
+
+  public static RekorClient2.Builder builder() {
+    return new RekorClient2.Builder();
+  }
+
+  private RekorClient2(HttpParams httpParams, TransparencyLog tlog) {
+    this.tlog = tlog;
+    this.httpParams = httpParams;
+  }
+
+  public static class Builder {
+    private HttpParams httpParams = ImmutableHttpParams.builder().build();
+    private TransparencyLog tlog;
+
+    private Builder() {}
+
+    /** Configure the http properties, see {@link HttpParams}, {@link ImmutableHttpParams}. */
+    public Builder setHttpParams(HttpParams httpParams) {
+      this.httpParams = httpParams;
+      return this;
+    }
+
+    /** Configure the remote rekor instance to communicate with. */
+    public Builder setTransparencyLog(TransparencyLog tlog) {
+      this.tlog = tlog;
+      return this;
+    }
+
+    public RekorClient2 build() {
+      Preconditions.checkNotNull(tlog);
+      return new RekorClient2(httpParams, tlog);
+    }
+  }
+
+  /**
+   * Put a new hashedrekord entry on the Rekor log.
+   *
+   * @param hashedRekordRequest the request to send to rekor
+   * @return a {@link RekorResponse} with information about the log entry
+   */
+  public RekorResponse putEntry(HashedRekordRequest hashedRekordRequest)
+      throws IOException, RekorParseException {
+    URI rekorPutEndpoint = tlog.getBaseUrl().resolve(REKOR_ENTRIES_PATH);
+
+    HttpRequest req =
+        HttpClients.newRequestFactory(httpParams)
+            .buildPostRequest(
+                new GenericUrl(rekorPutEndpoint),
+                ByteArrayContent.fromString(
+                    "application/json", hashedRekordRequest.toJsonPayload()));
+    req.getHeaders().set("Accept", "application/json");
+    req.getHeaders().set("Content-Type", "application/json");
+
+    HttpResponse resp = req.execute();
+    if (resp.getStatusCode() != 201) {
+      throw new IOException(
+          String.format(
+              Locale.ROOT,
+              "bad response from rekor @ '%s' : %s",
+              rekorPutEndpoint,
+              resp.parseAsString()));
+    }
+
+    URI rekorEntryUri = tlog.getBaseUrl().resolve(resp.getHeaders().getLocation());
+    String entry = resp.parseAsString();
+    return RekorResponse.newRekorResponse(rekorEntryUri, entry);
+  }
+
+  public Optional<RekorEntry> getEntry(HashedRekordRequest hashedRekordRequest)
+      throws IOException, RekorParseException {
+    return getEntry(hashedRekordRequest.computeUUID());
+  }
+
+  public Optional<RekorEntry> getEntry(String UUID) throws IOException, RekorParseException {
+    URI getEntryURI = tlog.getBaseUrl().resolve(REKOR_ENTRIES_PATH + "/" + UUID);
+    HttpRequest req =
+        HttpClients.newRequestFactory(httpParams).buildGetRequest(new GenericUrl(getEntryURI));
+    req.getHeaders().set("Accept", "application/json");
+    HttpResponse response;
+    try {
+      response = req.execute();
+    } catch (HttpResponseException e) {
+      if (e.getStatusCode() == 404) return Optional.empty();
+      throw e;
+    }
+    return Optional.of(
+        RekorResponse.newRekorResponse(getEntryURI, response.parseAsString()).getEntry());
+  }
+
+  /**
+   * Returns a list of UUIDs for matching entries for the given search parameters.
+   *
+   * @param email the OIDC email subject
+   * @param hash sha256 hash of the artifact
+   * @param publicKeyFormat format of public key (one of 'pgp','x509','minisign', 'ssh', 'tuf')
+   * @param publicKeyContent public key base64 encoded content
+   */
+  public List<String> searchEntry(
+      String email, String hash, String publicKeyFormat, String publicKeyContent)
+      throws IOException {
+    URI rekorSearchEndpoint = tlog.getBaseUrl().resolve(REKOR_INDEX_SEARCH_PATH);
+
+    HashMap<String, Object> publicKeyParams = null;
+    if (publicKeyContent != null) {
+      publicKeyParams = new HashMap<>();
+      publicKeyParams.put("format", publicKeyFormat);
+      publicKeyParams.put("content", publicKeyContent);
+    }
+    var data = new HashMap<String, Object>();
+    data.put("email", email);
+    data.put("hash", hash);
+    data.put("publicKey", publicKeyParams);
+
+    String contentString = GSON.get().toJson(data);
+    HttpRequest req =
+        HttpClients.newRequestFactory(httpParams)
+            .buildPostRequest(
+                new GenericUrl(rekorSearchEndpoint),
+                ByteArrayContent.fromString("application/json", contentString));
+    req.getHeaders().set("Accept", "application/json");
+    req.getHeaders().set("Content-Type", "application/json");
+    var response = req.execute();
+    return Arrays.asList(GSON.get().fromJson(response.parseAsString(), String[].class));
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClient2Test.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClient2Test.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.rekor.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.encryption.signers.Signers;
+import dev.sigstore.testing.CertGenerator;
+import dev.sigstore.trustroot.ImmutableTransparencyLog;
+import dev.sigstore.trustroot.LogId;
+import dev.sigstore.trustroot.PublicKey;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.util.Optional;
+import java.util.UUID;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class RekorClient2Test {
+
+  private static final String REKOR_URL = "https://rekor.sigstage.dev";
+  private RekorClient2 client;
+
+  @BeforeEach
+  public void setupClient() throws URISyntaxException {
+    // this tests directly against rekor in staging, it's a bit hard to bring up a rekor instance
+    // without docker compose.
+    client =
+        RekorClient2.builder()
+            .setTransparencyLog(
+                ImmutableTransparencyLog.builder()
+                    .baseUrl(URI.create(REKOR_URL))
+                    .hashAlgorithm("ignored")
+                    .publicKey(Mockito.mock(PublicKey.class))
+                    .logId(Mockito.mock(LogId.class))
+                    .build())
+            .build();
+  }
+
+  @Test
+  public void putEntry_toStaging() throws Exception {
+    HashedRekordRequest req = createdRekorRequest();
+    var resp = client.putEntry(req);
+
+    // pretty basic testing
+    MatcherAssert.assertThat(
+        resp.getEntryLocation().toString(),
+        CoreMatchers.startsWith(REKOR_URL + "/api/v1/log/entries/"));
+
+    assertNotNull(resp.getUuid());
+    assertNotNull(resp.getRaw());
+    var entry = resp.getEntry();
+    assertNotNull(entry.getBody());
+    Assertions.assertTrue(entry.getIntegratedTime() > 1);
+    assertNotNull(entry.getLogID());
+    Assertions.assertTrue(entry.getLogIndex() > 0);
+    assertNotNull(entry.getVerification().getSignedEntryTimestamp());
+    //    Assertions.assertNotNull(entry.getVerification().getInclusionProof());
+  }
+
+  // TODO(patrick@chainguard.dev): don't use data from prod, create the data as part of the test
+  // setup in staging.
+  @Test
+  public void searchEntries_nullParams() throws IOException {
+    assertEquals(ImmutableList.of(), client.searchEntry(null, null, null, null));
+  }
+
+  @Test
+  public void searchEntries_oneResult_hash() throws Exception {
+    var newRekordRequest = createdRekorRequest();
+    client.putEntry(newRekordRequest);
+    assertEquals(
+        1,
+        client
+            .searchEntry(
+                null, newRekordRequest.getHashedRekord().getData().getHash().getValue(), null, null)
+            .size());
+  }
+
+  @Test
+  public void searchEntries_oneResult_publicKey() throws Exception {
+    var newRekordRequest = createdRekorRequest();
+    var resp = client.putEntry(newRekordRequest);
+    assertEquals(
+        1,
+        client
+            .searchEntry(
+                null,
+                null,
+                "x509",
+                RekorTypes.getHashedRekord(resp.getEntry())
+                    .getSignature()
+                    .getPublicKey()
+                    .getContent())
+            .size());
+  }
+
+  @Test
+  public void searchEntries_moreThanOneResult_email() throws Exception {
+    var newRekordRequest = createdRekorRequest();
+    var newRekordRequest2 = createdRekorRequest();
+    client.putEntry(newRekordRequest);
+    client.putEntry(newRekordRequest2);
+    assertTrue(
+        client.searchEntry("test@test.com", null, null, null).size()
+            > 1); // as long as our tests use staging this is just going to grow.
+  }
+
+  @Test
+  public void searchEntries_zeroResults() throws IOException {
+    assertTrue(
+        client
+            .searchEntry(
+                null,
+                "sha256:9f54fad117567ab4c2c6738beef765f7c362550534ffc0bfe8d96b0236d69661", // made
+                // up sha
+                null,
+                null)
+            .isEmpty());
+  }
+
+  @Test
+  public void getEntry_entryExists() throws Exception {
+    var newRekordRequest = createdRekorRequest();
+    var resp = client.putEntry(newRekordRequest);
+    var entry = client.getEntry(resp.getUuid());
+    assertEntry(resp, entry);
+  }
+
+  @Test
+  public void getEntry_hashedRekordRequest_byCalculatedUuid() throws Exception {
+    var hashedRekordRequest = createdRekorRequest();
+    var resp = client.putEntry(hashedRekordRequest);
+    // getting an entry by hashedrekordrequest should implicitly calculate uuid
+    // from the contents of the hashedrekord
+    var entry = client.getEntry(hashedRekordRequest);
+    assertEntry(resp, entry);
+  }
+
+  private void assertEntry(RekorResponse resp, Optional<RekorEntry> entry) {
+    assertTrue(entry.isPresent());
+    assertEquals(resp.getEntry().getLogID(), entry.get().getLogID());
+    assertTrue(entry.get().getVerification().getInclusionProof().isPresent());
+    assertNotNull(entry.get().getVerification().getInclusionProof().get().getTreeSize());
+    assertNotNull(entry.get().getVerification().getInclusionProof().get().getRootHash());
+    assertNotNull(entry.get().getVerification().getInclusionProof().get().getLogIndex());
+    assertTrue(entry.get().getVerification().getInclusionProof().get().getHashes().size() > 0);
+  }
+
+  @Test
+  public void getEntry_entryDoesntExist() throws Exception {
+    Optional<RekorEntry> entry =
+        client.getEntry(
+            "a8d2b213aa7efc1b2c9ccfa2fa647d00b34c63972e04e90276b5c31e0f317afd"); // I made this up
+    assertTrue(entry.isEmpty());
+  }
+
+  @NotNull
+  private HashedRekordRequest createdRekorRequest()
+      throws NoSuchAlgorithmException, InvalidKeyException, SignatureException,
+          OperatorCreationException, CertificateException, IOException {
+    // the data we want to sign
+    var data = "some data " + UUID.randomUUID();
+
+    // get the digest
+    var artifactDigest =
+        MessageDigest.getInstance("SHA-256").digest(data.getBytes(StandardCharsets.UTF_8));
+
+    // sign the full content (these signers do the artifact hashing themselves)
+    var signer = Signers.newEcdsaSigner();
+    var signature = signer.sign(data.getBytes(StandardCharsets.UTF_8));
+
+    // create a fake signing cert (not fulcio/dex)
+    var cert = Certificates.toPemBytes(CertGenerator.newCert(signer.getPublicKey()));
+
+    return HashedRekordRequest.newHashedRekordRequest(artifactDigest, cert, signature);
+  }
+}


### PR DESCRIPTION
Part 1 of plumbing tuf into rekor. I think the only difference between this and the original client is where the url comes from.

```diff
20c20,25
< import com.google.api.client.http.*;
---
> import com.google.api.client.http.ByteArrayContent;
> import com.google.api.client.http.GenericUrl;
> import com.google.api.client.http.HttpRequest;
> import com.google.api.client.http.HttpResponse;
> import com.google.api.client.http.HttpResponseException;
> import com.google.common.base.Preconditions;
23a29
> import dev.sigstore.trustroot.TransparencyLog;
26c32,36
< import java.util.*;
---
> import java.util.Arrays;
> import java.util.HashMap;
> import java.util.List;
> import java.util.Locale;
> import java.util.Optional;
29,31c39
< public class RekorClient {
<   public static final String PUBLIC_REKOR_SERVER = "https://rekor.sigstore.dev";
<   public static final String STAGING_REKOR_SERVER = "https://rekor.sigstage.dev";
---
> public class RekorClient2 {
36c44
<   private final URI serverUrl;
---
>   private final TransparencyLog tlog;
38,39c46,47
<   public static RekorClient.Builder builder() {
<     return new RekorClient.Builder();
---
>   public static RekorClient2.Builder builder() {
>     return new RekorClient2.Builder();
42,43c50,51
<   private RekorClient(HttpParams httpParams, URI serverUrl) {
<     this.serverUrl = serverUrl;
---
>   private RekorClient2(HttpParams httpParams, TransparencyLog tlog) {
>     this.tlog = tlog;
48d55
<     private URI serverUrl = URI.create(PUBLIC_REKOR_SERVER);
49a57
>     private TransparencyLog tlog;
54c62
<     public RekorClient.Builder setHttpParams(HttpParams httpParams) {
---
>     public Builder setHttpParams(HttpParams httpParams) {
59,61c67,69
<     /** The fulcio remote server URI, defaults to {@value PUBLIC_REKOR_SERVER}. */
<     public RekorClient.Builder setServerUrl(URI uri) {
<       this.serverUrl = uri;
---
>     /** Configure the remote rekor instance to communicate with. */
>     public Builder setTransparencyLog(TransparencyLog tlog) {
>       this.tlog = tlog;
65,66c73,75
<     public RekorClient build() {
<       return new RekorClient(httpParams, serverUrl);
---
>     public RekorClient2 build() {
>       Preconditions.checkNotNull(tlog);
>       return new RekorClient2(httpParams, tlog);
78c87
<     URI rekorPutEndpoint = serverUrl.resolve(REKOR_ENTRIES_PATH);
---
>     URI rekorPutEndpoint = tlog.getBaseUrl().resolve(REKOR_ENTRIES_PATH);
99c108
<     URI rekorEntryUri = serverUrl.resolve(resp.getHeaders().getLocation());
---
>     URI rekorEntryUri = tlog.getBaseUrl().resolve(resp.getHeaders().getLocation());
110c119
<     URI getEntryURI = serverUrl.resolve(REKOR_ENTRIES_PATH + "/" + UUID);
---
>     URI getEntryURI = tlog.getBaseUrl().resolve(REKOR_ENTRIES_PATH + "/" + UUID);
136c145
<     URI rekorSearchEndpoint = serverUrl.resolve(REKOR_INDEX_SEARCH_PATH);
---
>     URI rekorSearchEndpoint = tlog.getBaseUrl().resolve(REKOR_INDEX_SEARCH_PATH);

```