### PR TITLE
configure rekor verifier (v2 for now) with trustroot

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorVerifier2.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorVerifier2.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.rekor.client;
+
+import com.google.common.hash.Hashing;
+import dev.sigstore.encryption.signers.Verifiers;
+import dev.sigstore.trustroot.SigstoreTrustedRoot;
+import dev.sigstore.trustroot.TransparencyLogs;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Instant;
+import java.util.Base64;
+import org.bouncycastle.util.encoders.Hex;
+
+/** Verifier for rekor entries. */
+public class RekorVerifier2 {
+  private final TransparencyLogs tlogs;
+
+  public static RekorVerifier2 newRekorVerifier(SigstoreTrustedRoot trustRoot) {
+    return newRekorVerifier(trustRoot.getTLogs());
+  }
+
+  public static RekorVerifier2 newRekorVerifier(TransparencyLogs tlogs) {
+    return new RekorVerifier2(tlogs);
+  }
+
+  private RekorVerifier2(TransparencyLogs tlogs) {
+    this.tlogs = tlogs;
+  }
+
+  /**
+   * Verify that a Rekor Entry is signed with the rekor public key loaded into this verifier
+   *
+   * @param entry the entry to verify
+   * @throws RekorVerificationException if the entry cannot be verified
+   */
+  public void verifyEntry(RekorEntry entry) throws RekorVerificationException {
+    if (entry.getVerification() == null) {
+      throw new RekorVerificationException("No verification information in entry.");
+    }
+
+    if (entry.getVerification().getSignedEntryTimestamp() == null) {
+      throw new RekorVerificationException("No signed entry timestamp found in entry.");
+    }
+
+    var tlog =
+        tlogs
+            .find(Hex.decode(entry.getLogID()), Instant.ofEpochSecond(entry.getIntegratedTime()))
+            .orElseThrow(
+                () ->
+                    new RekorVerificationException(
+                        "Log entry (logid, timestamp) does not match any provided transparency logs."));
+
+    try {
+      var verifier = Verifiers.newVerifier(tlog.getPublicKey().toJavaPublicKey());
+      if (!verifier.verify(
+          entry.getSignableContent(),
+          Base64.getDecoder().decode(entry.getVerification().getSignedEntryTimestamp()))) {
+        throw new RekorVerificationException("Entry SET was not valid");
+      }
+    } catch (InvalidKeySpecException ike) {
+      throw new RekorVerificationException("Public Key could be parsed", ike);
+    } catch (InvalidKeyException ike) {
+      throw new RekorVerificationException("Public Key was invalid", ike);
+    } catch (SignatureException se) {
+      throw new RekorVerificationException("Signature was invalid", se);
+    } catch (NoSuchAlgorithmException nsae) {
+      throw new AssertionError("Required verification algorithm 'SHA256withECDSA' not found.");
+    }
+  }
+
+  /**
+   * Verify that a Rekor Entry is in the log by checking inclusion proof.
+   *
+   * @param entry the entry to verify
+   * @throws RekorVerificationException if the entry cannot be verified
+   */
+  public void verifyInclusionProof(RekorEntry entry) throws RekorVerificationException {
+
+    var inclusionProof =
+        entry
+            .getVerification()
+            .getInclusionProof()
+            .orElseThrow(
+                () ->
+                    new RekorVerificationException(
+                        "No inclusion proof was found in the rekor entry"));
+
+    var leafHash =
+        Hashing.sha256()
+            .hashBytes(combineBytes(new byte[] {0x00}, Base64.getDecoder().decode(entry.getBody())))
+            .asBytes();
+
+    // see: https://datatracker.ietf.org/doc/rfc9162/ section 2.1.3.2
+
+    // nodeIndex and totalNodes represent values for a specific level in the tree
+    // starting at the leafs and moving up to the root.
+    var nodeIndex = inclusionProof.getLogIndex();
+    var totalNodes = inclusionProof.getTreeSize() - 1;
+
+    var currentHash = leafHash;
+    var hashes = inclusionProof.getHashes();
+
+    for (var hash : hashes) {
+      byte[] p = Hex.decode(hash);
+      if (totalNodes == 0) {
+        throw new RekorVerificationException("Inclusion proof failed, ended prematurely");
+      }
+      if (nodeIndex == totalNodes || nodeIndex % 2 == 1) {
+        currentHash = hashChildren(p, currentHash);
+        while (nodeIndex % 2 == 0) {
+          nodeIndex = nodeIndex >> 1;
+          totalNodes = totalNodes >> 1;
+        }
+      } else {
+        currentHash = hashChildren(currentHash, p);
+      }
+      nodeIndex = nodeIndex >> 1;
+      totalNodes = totalNodes >> 1;
+    }
+
+    var calcuatedRootHash = Hex.toHexString(currentHash);
+    if (!calcuatedRootHash.equals(inclusionProof.getRootHash())) {
+      throw new RekorVerificationException(
+          "Calculated inclusion proof root hash does not match provided root hash\n"
+              + calcuatedRootHash
+              + "\n"
+              + inclusionProof.getRootHash());
+    }
+  }
+
+  private static byte[] combineBytes(byte[] first, byte[] second) {
+    byte[] result = new byte[first.length + second.length];
+    System.arraycopy(first, 0, result, 0, first.length);
+    System.arraycopy(second, 0, result, first.length, second.length);
+    return result;
+  }
+
+  // hash the concatination of 0x01, left and right
+  private static byte[] hashChildren(byte[] left, byte[] right) {
+    return Hashing.sha256()
+        .hashBytes(combineBytes(new byte[] {0x01}, combineBytes(left, right)))
+        .asBytes();
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifier2Test.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifier2Test.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.rekor.client;
+
+import com.google.common.io.Resources;
+import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import dev.sigstore.trustroot.ImmutableLogId;
+import dev.sigstore.trustroot.ImmutablePublicKey;
+import dev.sigstore.trustroot.ImmutableTransparencyLog;
+import dev.sigstore.trustroot.ImmutableTransparencyLogs;
+import dev.sigstore.trustroot.ImmutableValidFor;
+import dev.sigstore.trustroot.SigstoreTrustedRoot;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.bouncycastle.util.encoders.Base64;
+import org.bouncycastle.util.encoders.Hex;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RekorVerifier2Test {
+  public String rekorResponse;
+  public String rekorQueryResponse;
+  public byte[] rekorPub;
+
+  public static SigstoreTrustedRoot trustRoot;
+
+  @BeforeEach
+  public void loadResources() throws IOException {
+    rekorResponse =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/rekor-response/valid/response.json"),
+            StandardCharsets.UTF_8);
+    rekorPub =
+        Resources.toByteArray(
+            Resources.getResource("dev/sigstore/samples/rekor-response/valid/rekor.pub"));
+    rekorQueryResponse =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/rekor-response/valid/query-response.json"),
+            StandardCharsets.UTF_8);
+  }
+
+  @BeforeAll
+  public static void initTrustRoot() throws IOException, CertificateException {
+    var json =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/trustroot/staging_trusted_root.json"),
+            StandardCharsets.UTF_8);
+    var builder = TrustedRoot.newBuilder();
+    JsonFormat.parser().merge(json, builder);
+
+    trustRoot = SigstoreTrustedRoot.from(builder.build());
+  }
+
+  @Test
+  public void verifyEntry_valid() throws Exception {
+    var response = RekorResponse.newRekorResponse(new URI("https://somewhere"), rekorResponse);
+    var verifier = RekorVerifier2.newRekorVerifier(trustRoot);
+
+    verifier.verifyEntry(response.getEntry());
+  }
+
+  @Test
+  public void verifyEntry_invalid() throws Exception {
+    // change the logindex
+    var invalidResponse = rekorResponse.replace("79", "80");
+    var response = RekorResponse.newRekorResponse(new URI("https://somewhere"), invalidResponse);
+    var verifier = RekorVerifier2.newRekorVerifier(trustRoot);
+
+    var thrown =
+        Assertions.assertThrows(
+            RekorVerificationException.class, () -> verifier.verifyEntry(response.getEntry()));
+    Assertions.assertEquals("Entry SET was not valid", thrown.getMessage());
+  }
+
+  @Test
+  public void verifyEntry_withInclusionProof() throws Exception {
+    var response = RekorResponse.newRekorResponse(new URI("https://somewhere"), rekorQueryResponse);
+    var verifier = RekorVerifier2.newRekorVerifier(trustRoot);
+
+    var entry = response.getEntry();
+    verifier.verifyEntry(entry);
+    verifier.verifyInclusionProof(entry);
+  }
+
+  @Test
+  public void verifyEntry_withInvalidInclusionProof() throws Exception {
+    // replace a hash in the inclusion proof to make it bad
+    var invalidResponse = rekorQueryResponse.replace("b4439e", "aaaaaa");
+
+    var response = RekorResponse.newRekorResponse(new URI("https://somewhere"), invalidResponse);
+    var verifier = RekorVerifier2.newRekorVerifier(trustRoot);
+
+    var entry = response.getEntry();
+    verifier.verifyEntry(entry);
+
+    var thrown =
+        Assertions.assertThrows(
+            RekorVerificationException.class, () -> verifier.verifyInclusionProof(entry));
+    MatcherAssert.assertThat(
+        thrown.getMessage(),
+        CoreMatchers.startsWith(
+            "Calculated inclusion proof root hash does not match provided root hash"));
+  }
+
+  @Test
+  public void verifyEntry_logIdMismatch() throws Exception {
+    var response = RekorResponse.newRekorResponse(new URI("https://somewhere"), rekorResponse);
+    var tlog =
+        ImmutableTransparencyLog.builder()
+            .logId(
+                ImmutableLogId.builder().keyId("garbage".getBytes(StandardCharsets.UTF_8)).build())
+            .publicKey(
+                ImmutablePublicKey.builder()
+                    .validFor(ImmutableValidFor.builder().start(Instant.EPOCH).build())
+                    .keyDetails("PKIX_ECDSA_P256_SHA_256")
+                    .rawBytes(
+                        Base64.decode(
+                            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDODRU688UYGuy54mNUlaEBiQdTE9nYLr0lg6RXowI/QV/RE1azBn4Eg5/2uTOMbhB1/gfcHzijzFi9Tk+g1Prg=="))
+                    .build())
+            .hashAlgorithm("ignored")
+            .baseUrl(URI.create("ignored"))
+            .build();
+
+    var verifier =
+        RekorVerifier2.newRekorVerifier(
+            ImmutableTransparencyLogs.builder().addTransparencyLog(tlog).build());
+
+    // make sure the entry time is valid for the log -- so we can determine the logid is the error
+    // creator
+    Assertions.assertTrue(
+        tlog.getPublicKey()
+            .getValidFor()
+            .contains(Instant.ofEpochSecond(response.getEntry().getIntegratedTime())));
+
+    var thrown =
+        Assertions.assertThrows(
+            RekorVerificationException.class, () -> verifier.verifyEntry(response.getEntry()));
+    Assertions.assertEquals(
+        "Log entry (logid, timestamp) does not match any provided transparency logs.",
+        thrown.getMessage());
+  }
+
+  @Test
+  public void verifyEntry_logIdTimeMismatch() throws Exception {
+
+    var response = RekorResponse.newRekorResponse(new URI("https://somewhere"), rekorResponse);
+
+    var tlog =
+        ImmutableTransparencyLog.builder()
+            .logId(
+                ImmutableLogId.builder()
+                    .keyId(Base64.decode("0y8wo8MtY5wrdiIFohx7sHeI5oKDpK5vQhGHI6G+pJY="))
+                    .build())
+            .publicKey(
+                ImmutablePublicKey.builder()
+                    .validFor(
+                        ImmutableValidFor.builder()
+                            .start(Instant.EPOCH)
+                            .end(Instant.EPOCH.plus(1, ChronoUnit.SECONDS))
+                            .build())
+                    .keyDetails("PKIX_ECDSA_P256_SHA_256")
+                    .rawBytes(
+                        Base64.decode(
+                            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDODRU688UYGuy54mNUlaEBiQdTE9nYLr0lg6RXowI/QV/RE1azBn4Eg5/2uTOMbhB1/gfcHzijzFi9Tk+g1Prg=="))
+                    .build())
+            .hashAlgorithm("ignored")
+            .baseUrl(URI.create("ignored"))
+            .build();
+
+    var verifier =
+        RekorVerifier2.newRekorVerifier(
+            ImmutableTransparencyLogs.builder().addTransparencyLog(tlog).build());
+
+    // make sure logId is equal -- so we can determine the time is the error creator
+    Assertions.assertArrayEquals(
+        tlog.getLogId().getKeyId(), Hex.decode(response.getEntry().getLogID()));
+
+    var thrown =
+        Assertions.assertThrows(
+            RekorVerificationException.class, () -> verifier.verifyEntry(response.getEntry()));
+    Assertions.assertEquals(
+        "Log entry (logid, timestamp) does not match any provided transparency logs.",
+        thrown.getMessage());
+  }
+}

--- a/sigstore-java/src/test/resources/dev/sigstore/trustroot/README.me
+++ b/sigstore-java/src/test/resources/dev/sigstore/trustroot/README.me
@@ -1,2 +1,5 @@
 trusted_root.json was pulled from prod in April 2023
 https://github.com/sigstore/root-signing/blob/f50a9debad1db8c4e44d571147968c4061344f5f/targets/trusted_root.json
+
+staging_trusted_root.json was pulled in Aug 2023
+https://github.com/sigstore/root-signing/blob/43f495fab8ad5490f6efb3fd92f58f3de3011a4c/staging/targets/trusted_root.json

--- a/sigstore-java/src/test/resources/dev/sigstore/trustroot/staging_trusted_root.json
+++ b/sigstore-java/src/test/resources/dev/sigstore/trustroot/staging_trusted_root.json
@@ -1,0 +1,110 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+  "tlogs": [
+    {
+      "baseUrl": "https://rekor.sigstage.dev",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDODRU688UYGuy54mNUlaEBiQdTE9nYLr0lg6RXowI/QV/RE1azBn4Eg5/2uTOMbhB1/gfcHzijzFi9Tk+g1Prg==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2021-01-12T11:53:27.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "0y8wo8MtY5wrdiIFohx7sHeI5oKDpK5vQhGHI6G+pJY="
+      }
+    }
+  ],
+  "certificateAuthorities": [
+    {
+      "subject": {
+        "organization": "sigstore.dev",
+        "commonName": "sigstore"
+      },
+      "uri": "https://fulcio.sigstage.dev",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICGTCCAaCgAwIBAgITJta/okfgHvjabGm1BOzuhrwA1TAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIyMDQxNDIxMzg0MFoXDTMyMDMyMjE2NTA0NVowNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAASosAySWJQ/tK5r8T5aHqavk0oI+BKQbnLLdmOMRXHQF/4Hx9KtNfpcdjH9hNKQSBxSlLFFN3tvFCco0qFBzWYwZtsYsBe1l91qYn/9VHFTaEVwYQWIJEEvrs0fvPuAqjajezB5MA4GA1UdDwEB/wQEAwIBBjATBgNVHSUEDDAKBggrBgEFBQcDAzASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBRxhjCmFHxib/n31vQFGn9f/+tvrDAfBgNVHSMEGDAWgBT/QjK6aH2rOnCv3AzUGuI+h49mZTAKBggqhkjOPQQDAwNnADBkAjAM1lbKkcqQlE/UspMTbWNo1y2TaJ44tx3l/FJFceTSdDZ+0W1OHHeU4twie/lq8XgCMHQxgEv26xNNiAGyPXbkYgrDPvbOqp0UeWX4mJnLSrBr3aN/KX1SBrKQu220FmVL0Q=="
+          },
+          {
+            "rawBytes": "MIIB9jCCAXugAwIBAgITDdEJvluliE0AzYaIE4jTMdnFTzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIyMDMyNTE2NTA0NloXDTMyMDMyMjE2NTA0NVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABMo9BUNk9QIYisYysC24+2OytoV72YiLonYcqR3yeVnYziPt7Xv++CYE8yoCTiwedUECCWKOcvQKRCJZb9ht4Hzy+VvBx36hK+C6sECCSR0x6pPSiz+cTk1f788ZjBlUZaNjMGEwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFP9CMrpofas6cK/cDNQa4j6Hj2ZlMB8GA1UdIwQYMBaAFP9CMrpofas6cK/cDNQa4j6Hj2ZlMAoGCCqGSM49BAMDA2kAMGYCMQD+kojuzMwztNay9Ibzjuk//ZL5m6T2OCsm45l1lY004pcb984L926BowodoirFMcMCMQDIJtFHhP/1D3a+M3dAGomOb6O4CmTry3TTPbPsAFnv22YA0Y+P21NVoxKDjdu0tkw="
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2022-04-14T21:38:40.000Z"
+      }
+    }
+  ],
+  "ctlogs": [
+    {
+      "baseUrl": "https://ctfe.sigstage.dev/test",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MIICCgKCAgEA27A2MPQXm0I0v7/Ly5BIauDjRZF5Jor9vU+QheoE2UIIsZHcyYq3slHzSSHy2lLj1ZD2d91CtJ492ZXqnBmsr4TwZ9jQ05tW2mGIRI8u2DqN8LpuNYZGz/f9SZrjhQQmUttqWmtu3UoLfKz6NbNXUnoo+NhZFcFRLXJ8VporVhuiAmL7zqT53cXR3yQfFPCUDeGnRksnlhVIAJc3AHZZSHQJ8DEXMhh35TVv2nYhTI3rID7GwjXXw4ocz7RGDD37ky6p39Tl5NB71gT1eSqhZhGHEYHIPXraEBd5+3w9qIuLWlp5Ej/K6Mu4ELioXKCUimCbwy+Cs8UhHFlqcyg4AysOHJwIadXIa8LsY51jnVSGrGOEBZevopmQPNPtyfFY3dmXSS+6Z3RD2Gd6oDnNGJzpSyEk410Ag5uvNDfYzJLCWX9tU8lIxNwdFYmIwpd89HijyRyoGnoJ3entd63cvKfuuix5r+GHyKp1Xm1L5j5AWM6P+z0xigwkiXnt+adexAl1J9wdDxv/pUFEESRF4DG8DFGVtbdH6aR1A5/vD4krO4tC1QYUSeyL5Mvsw8WRqIFHcXtgybtxylljvNcGMV1KXQC8UFDmpGZVDSHx6v3e/BHMrZ7gjoCCfVMZ/cFcQi0W2AIHPYEMH/C95J2r4XbHMRdYXpovpOoT5Ca78gsCAwEAAQ==",
+        "keyDetails": "PKCS1_RSA_PKCS1V5",
+        "validFor": {
+          "start": "2021-03-14T00:00:00.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "G3wUKk6ZK6ffHh/FdCRUE2wVekyzHEEIpSG4savnv0w="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstage.dev/2022",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEh99xuRi6slBFd8VUJoK/rLigy4bYeSYWO/fE6Br7r0D8NpMI94+A63LR/WvLxpUUGBpY8IJA3iU2telag5CRpA==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-07-01T00:00:00.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "++JKOMQt7SJ3ynUHnCfnDhcKP8/58J4TueMqXuk3HmA="
+      }
+    },
+    {
+      "baseUrl": "https://ctfe.sigstage.dev/2022-2",
+      "hashAlgorithm": "SHA2_256",
+      "publicKey": {
+        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8gEDKNme8AnXuPBgHjrtXdS6miHqc24CRblNEOFpiJRngeq8Ko73Y+K18yRYVf1DXD4AVLwvKyzdNdl5n0jUSQ==",
+        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+        "validFor": {
+          "start": "2022-07-01T00:00:00.000Z"
+        }
+      },
+      "logId": {
+        "keyId": "KzC83GiIyeLh2CYpXnQfSDkxlgLynDPLXkNA/rKshno="
+      }
+    }
+  ],
+  "timestampAuthorities": [
+    {
+      "subject": {
+        "organization": "GitHub, Inc.",
+        "commonName": "Internal Services Root - staging"
+      },
+      "uri": "tsa.github.internal",
+      "certChain": {
+        "certificates": [
+          {
+            "rawBytes": "MIICEzCCAZigAwIBAgIUMpRykCcZaSOBipYce6r2DlnM7vUwCgYIKoZIzj0EAwMwPDEVMBMGA1UEChMMR2l0SHViLCBJbmMuMSMwIQYDVQQDExpUU0EgaW50ZXJtZWRpYXRlIC0gc3RhZ2luZzAeFw0yMzA2MTQxMjAwMDBaFw0yNDA2MTMxMjAwMDBaMDwxFTATBgNVBAoTDEdpdEh1YiwgSW5jLjEjMCEGA1UEAxMaVFNBIFRpbWVzdGFtcGluZyAtIHN0YWdpbmcwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATWAMg1BEHAzb03PHUKJiRJZdXcKIL0K/ks3Ylq5F5YDRIxUN4o8yeIaCWXa6i16zi8nXMFsa+3XrYM8mUyi9F6o3gwdjAOBgNVHQ8BAf8EBAMCB4AwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUr+RZdcTNo31p3FuR0pajelcnr40wHwYDVR0jBBgwFoAUCmpQzrB6hAnlizGx37LrhKEzsT4wFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwgwCgYIKoZIzj0EAwMDaQAwZgIxAIPUlZB2/p5rpCM3HCn1R8G5TIIW6aZPKtfPWDkNQY0bpFu6e8Dkm2TV3jfgYExuBgIxAOA+vTlDDJoz/qTMMs8VSpw3AMgktlMEhd8V0E+aLW5OizfphuiidkqkqkbCwRSW1w=="
+          },
+          {
+            "rawBytes": "MIICNzCCAb6gAwIBAgIUUXRsBKgGXjrJbdJCQPJMsjfyJcYwCgYIKoZIzj0EAwMwQjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMSkwJwYDVQQDEyBJbnRlcm5hbCBTZXJ2aWNlcyBSb290IC0gc3RhZ2luZzAeFw0yMzA2MTQwMDAwMDBaFw0yODA2MTIwMDAwMDBaMDwxFTATBgNVBAoTDEdpdEh1YiwgSW5jLjEjMCEGA1UEAxMaVFNBIGludGVybWVkaWF0ZSAtIHN0YWdpbmcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAS/upihrvu/9+w1Ybfog3B1a8KfQa1bn7DLcJz2iumo+oCfg2bcbyRWygu8zRmrzJKp4HgQHC4LZJEEWm/MNIN1o6wVVmiDTZw01tk4aInmRVF13VKMscdzW5Ho4sYaeOejezB5MA4GA1UdDwEB/wQEAwIBBjATBgNVHSUEDDAKBggrBgEFBQcDCDASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQKalDOsHqECeWLMbHfsuuEoTOxPjAfBgNVHSMEGDAWgBR04GYtT79vaQmAEPPEte8q+W1KRTAKBggqhkjOPQQDAwNnADBkAjBOTWZP1QYnmHpFqL73eSzhmSLiHs9pXsQghK0p8pvlAg0R9bxAyXGIZ8qx+k2iIGcCMDRQIScz0gu2Xef3++p2vFYouBsIKbqxv0raJuIlmGiYEvb22MDpAitevKAgqNVMEg=="
+          },
+          {
+            "rawBytes": "MIICCDCCAY6gAwIBAgIULHHP/UhbXJbdyZfT6gHgTzIYF4EwCgYIKoZIzj0EAwMwQjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMSkwJwYDVQQDEyBJbnRlcm5hbCBTZXJ2aWNlcyBSb290IC0gc3RhZ2luZzAeFw0yMzA2MTQwMDAwMDBaFw0zMzA2MTEwMDAwMDBaMEIxFTATBgNVBAoTDEdpdEh1YiwgSW5jLjEpMCcGA1UEAxMgSW50ZXJuYWwgU2VydmljZXMgUm9vdCAtIHN0YWdpbmcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAASocByKBUdzgtqRXcpe/AE5oPoDMWTQqz1/jUQOA8qoEjYBXg9gfGU5KHK/UdwQc4lxbZEA9nJS9vUQAMVV5Es9B4thNHThKR4hFmCL8kKIEoMzXx282Qr6x4ZHYk4tQsCjRTBDMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgECMB0GA1UdDgQWBBR04GYtT79vaQmAEPPEte8q+W1KRTAKBggqhkjOPQQDAwNoADBlAjBBOu3RtlH1FLvfHPhyoWJHgm+PSNrsWQLRkmWQgAfNPYsfO5fWyhAebMV3FpKVPBICMQCVaie4NAsGi+AHLDhGnPn4Qptz0LBH2So6AVJS24ICeDUDQxKeUTNkUsy6Qgg97/4="
+          }
+        ]
+      },
+      "validFor": {
+        "start": "2023-06-15T00:00:00Z"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Uses trust root in the verifier, the only added check now is that log entries timestamp must be inside the validity period for a log's public key (but that's handled by the `find()` method in TransparencyLogs)

diff with old RekorVerifier.java
```diff
29,30c31,32
< public class RekorVerifier {
<   private final Verifier verifier;
---
> public class RekorVerifier2 {
>   private final TransparencyLogs tlogs;
32,38c34,36
<   // A calculated logId from the transparency log (rekor) public key
<   private final String calculatedLogId;
< 
<   public static RekorVerifier newRekorVerifier(byte[] rekorPublicKey)
<       throws InvalidKeySpecException, NoSuchAlgorithmException, IOException {
<     var publicKey = Keys.parsePublicKey(rekorPublicKey);
<     var verifier = Verifiers.newVerifier(publicKey);
---
>   public static RekorVerifier2 newRekorVerifier(SigstoreTrustedRoot trustRoot) {
>     return newRekorVerifier(trustRoot.getTLogs());
>   }
40c38,39
<     return new RekorVerifier(verifier);
---
>   public static RekorVerifier2 newRekorVerifier(TransparencyLogs tlogs) {
>     return new RekorVerifier2(tlogs);
43,46c42,43
<   private RekorVerifier(Verifier verifier) {
<     this.calculatedLogId =
<         Hashing.sha256().hashBytes(verifier.getPublicKey().getEncoded()).toString();
<     this.verifier = verifier;
---
>   private RekorVerifier2(TransparencyLogs tlogs) {
>     this.tlogs = tlogs;
55c52,53
<   public void verifyEntry(RekorEntry entry) throws RekorVerificationException {
---
>   public void verifyEntry(RekorEntry entry)
>       throws RekorVerificationException, InvalidKeySpecException, NoSuchAlgorithmException {
64,66c62,68
<     if (!entry.getLogID().equals(calculatedLogId)) {
<       throw new RekorVerificationException("LogId does not match supplied rekor public key.");
<     }
---
>     var tlog =
>         tlogs
>             .find(Hex.decode(entry.getLogID()), Instant.ofEpochSecond(entry.getIntegratedTime()))
>             .orElseThrow(
>                 () ->
>                     new RekorVerificationException(
>                         "Log entry (logid, timestamp) does not match any provided transparency logs."));
67a70
>     var verifier = Verifiers.newVerifier(tlog.getPublicKey().toJavaPublicKey());
```