### PR TITLE
Handle pkcs1 rsa keys in trsuted_root

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/Keys.java
@@ -80,13 +80,7 @@ public class Keys {
       throw new InvalidKeySpecException("Invalid key, empty PEM section");
     }
     if (section.getType().equals("RSA PUBLIC KEY")) {
-      ASN1Sequence sequence = ASN1Sequence.getInstance(section.getContent());
-      ASN1Integer modulus = ASN1Integer.getInstance(sequence.getObjectAt(0));
-      ASN1Integer exponent = ASN1Integer.getInstance(sequence.getObjectAt(1));
-      RSAPublicKeySpec keySpec =
-          new RSAPublicKeySpec(modulus.getPositiveValue(), exponent.getPositiveValue());
-      KeyFactory factory = KeyFactory.getInstance("RSA");
-      return factory.generatePublic(keySpec);
+      return parsePkcs1RsaPublicKey(section.getContent());
     }
 
     // otherwise, we are dealing with PKIX X509 encoded keys
@@ -126,6 +120,17 @@ public class Keys {
     X509EncodedKeySpec spec = new X509EncodedKeySpec(contents);
     KeyFactory factory = KeyFactory.getInstance(algorithm);
     return factory.generatePublic(spec);
+  }
+
+  public static PublicKey parsePkcs1RsaPublicKey(byte[] contents)
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    ASN1Sequence sequence = ASN1Sequence.getInstance(contents);
+    ASN1Integer modulus = ASN1Integer.getInstance(sequence.getObjectAt(0));
+    ASN1Integer exponent = ASN1Integer.getInstance(sequence.getObjectAt(1));
+    RSAPublicKeySpec keySpec =
+        new RSAPublicKeySpec(modulus.getPositiveValue(), exponent.getPositiveValue());
+    KeyFactory factory = KeyFactory.getInstance("RSA");
+    return factory.generatePublic(keySpec);
   }
 
   /**

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/PublicKey.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/PublicKey.java
@@ -31,11 +31,14 @@ public abstract class PublicKey {
 
   @Lazy
   public java.security.PublicKey toJavaPublicKey()
-      throws InvalidKeySpecException, NoSuchAlgorithmException {
-    if (!getKeyDetails().equals("PKIX_ECDSA_P256_SHA_256")) {
-      throw new InvalidKeySpecException("Unsupported key algorithm: " + getKeyDetails());
+      throws NoSuchAlgorithmException, InvalidKeySpecException {
+    if (getKeyDetails().equals("PKIX_ECDSA_P256_SHA_256")) {
+      return Keys.parsePkixPublicKey(getRawBytes(), "EC");
     }
-    return Keys.parsePkixPublicKey(getRawBytes(), "EC");
+    if (getKeyDetails().equals("PKCS1_RSA_PKCS1V5")) {
+      return Keys.parsePkcs1RsaPublicKey(getRawBytes());
+    }
+    throw new InvalidKeySpecException("Unsupported key algorithm: " + getKeyDetails());
   }
 
   public static PublicKey from(dev.sigstore.proto.common.v1.PublicKey proto) {

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
@@ -17,6 +17,7 @@ package dev.sigstore.tuf;
 
 import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import dev.sigstore.trustroot.SigstoreTrustedRoot;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -38,11 +39,8 @@ class SigstoreTufClientTest {
             .tufCacheLocation(localStorePath)
             .build();
     client.forceUpdate();
-    Assertions.assertNotNull(client.getSigstoreTrustedRoot());
 
-    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getTLogs().current());
-    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getCTLogs().current());
-    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getCAs().current());
+    assertTrustedRootValid(client.getSigstoreTrustedRoot());
   }
 
   @Test
@@ -50,11 +48,23 @@ class SigstoreTufClientTest {
     var client =
         SigstoreTufClient.builder().useStagingInstance().tufCacheLocation(localStorePath).build();
     client.forceUpdate();
-    Assertions.assertNotNull(client.getSigstoreTrustedRoot());
 
-    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getTLogs().current());
-    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getCTLogs().current());
-    Assertions.assertDoesNotThrow(() -> client.getSigstoreTrustedRoot().getCAs().current());
+    assertTrustedRootValid(client.getSigstoreTrustedRoot());
+  }
+
+  private void assertTrustedRootValid(SigstoreTrustedRoot trustedRoot) throws Exception {
+    Assertions.assertNotNull(trustedRoot);
+    Assertions.assertDoesNotThrow(() -> trustedRoot.getTLogs().current());
+    Assertions.assertDoesNotThrow(() -> trustedRoot.getCTLogs().current());
+    Assertions.assertDoesNotThrow(() -> trustedRoot.getCAs().current());
+
+    for (var tlog : trustedRoot.getTLogs()) {
+      Assertions.assertDoesNotThrow(() -> tlog.getPublicKey().toJavaPublicKey());
+    }
+
+    for (var ctlog : trustedRoot.getCTLogs()) {
+      Assertions.assertDoesNotThrow(() -> ctlog.getPublicKey().toJavaPublicKey());
+    }
   }
 
   @Test


### PR DESCRIPTION
Turns out staging uses a non ec key algorithm and we never handled it. So handle it.