### PR TITLE
Add RootProvider

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/RootProvider.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/RootProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** An interface for providing the tuf root to a client. */
+@FunctionalInterface
+public interface RootProvider {
+  String get() throws IOException;
+
+  static RootProvider fromResource(String resourceName) {
+    return () -> Resources.toString(Resources.getResource(resourceName), StandardCharsets.UTF_8);
+  }
+
+  static RootProvider fromFile(Path path) {
+    return () -> Files.readString(path);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -17,7 +17,6 @@ package dev.sigstore.tuf;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.io.Resources;
 import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.proto.trustroot.v1.TrustedRoot;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
@@ -63,7 +62,7 @@ public class SigstoreTufClient {
         Path.of(System.getProperty("user.home")).resolve(".sigstore-java").resolve("root");
 
     URL remoteMirror;
-    Path trustedRoot;
+    RootProvider trustedRoot;
 
     public Builder usePublicGoodInstance() {
       if (remoteMirror != null || trustedRoot != null) {
@@ -73,8 +72,7 @@ public class SigstoreTufClient {
       try {
         tufMirror(
             new URL("https://tuf-repo-cdn.sigstore.dev"),
-            Path.of(
-                Resources.getResource("dev/sigstore/tuf/sigstore-tuf-root/root.json").getPath()));
+            RootProvider.fromResource("dev/sigstore/tuf/sigstore-tuf-root/root.json"));
       } catch (MalformedURLException e) {
         throw new AssertionError(e);
       }
@@ -89,8 +87,7 @@ public class SigstoreTufClient {
       try {
         tufMirror(
             new URL("https://tuf-repo-cdn.sigstage.dev"),
-            Path.of(
-                Resources.getResource("dev/sigstore/tuf/tuf-root-staging/root.json").getPath()));
+            RootProvider.fromResource("dev/sigstore/tuf/tuf-root-staging/root.json"));
       } catch (MalformedURLException e) {
         throw new AssertionError(e);
       }
@@ -102,7 +99,7 @@ public class SigstoreTufClient {
       return this;
     }
 
-    public Builder tufMirror(URL mirror, Path trustedRoot) {
+    public Builder tufMirror(URL mirror, RootProvider trustedRoot) {
       this.remoteMirror = mirror;
       this.trustedRoot = trustedRoot;
       return this;

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -24,8 +24,6 @@ import dev.sigstore.encryption.signers.Verifiers;
 import dev.sigstore.tuf.model.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -58,14 +56,14 @@ public class Updater {
   private Verifiers.Supplier verifiers;
   private MetaFetcher fetcher;
   private ZonedDateTime updateStartTime;
-  private Path trustedRootPath;
+  private RootProvider trustedRootPath;
   private MutableTufStore localStore;
 
   Updater(
       Clock clock,
       Verifiers.Supplier verifiers,
       MetaFetcher fetcher,
-      Path trustedRootPath,
+      RootProvider trustedRootPath,
       MutableTufStore localStore) {
     this.clock = clock;
     this.verifiers = verifiers;
@@ -106,7 +104,7 @@ public class Updater {
     if (localRoot.isPresent()) {
       trustedRoot = localRoot.get();
     } else {
-      trustedRoot = GSON.get().fromJson(Files.readString(trustedRootPath), Root.class);
+      trustedRoot = GSON.get().fromJson(trustedRootPath.get(), Root.class);
     }
     int baseVersion = trustedRoot.getSignedMeta().getVersion();
     int nextVersion = baseVersion + 1;
@@ -437,7 +435,7 @@ public class Updater {
     private Verifiers.Supplier verifiers = Verifiers::newVerifier;
 
     private MetaFetcher fetcher;
-    private Path trustedRootPath;
+    private RootProvider trustedRootPath;
     private MutableTufStore localStore;
 
     public Builder setClock(Clock clock) {
@@ -455,7 +453,7 @@ public class Updater {
       return this;
     }
 
-    public Builder setTrustedRootPath(Path trustedRootPath) {
+    public Builder setTrustedRootPath(RootProvider trustedRootPath) {
       this.trustedRootPath = trustedRootPath;
       return this;
     }

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
@@ -937,7 +937,7 @@ class UpdaterTest {
         .setClock(Clock.fixed(Instant.parse(time), ZoneOffset.UTC))
         .setVerifiers(Verifiers::newVerifier)
         .setFetcher(HttpMetaFetcher.newFetcher(new URL(remoteUrl)))
-        .setTrustedRootPath(trustedRootFile)
+        .setTrustedRootPath(RootProvider.fromFile(trustedRootFile))
         .setLocalStore(FileSystemTufStore.newFileSystemStore(localStore))
         .build();
   }


### PR DESCRIPTION
Enable the selection of the source of the TUF root as a resource or file (or whatever implements the interface).

This also fixes the uses of the TUF client when loading the library as a jar as resources are not available as simple Path types.
