### PR TITLE
Minor update to builder usage

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -264,7 +264,7 @@ public class KeylessSigner implements AutoCloseable {
       rekorVerifier.verifyEntry(rekorResponse.getEntry());
 
       result.add(
-          ImmutableKeylessSignature.builder()
+          KeylessSignature.builder()
               .digest(artifactDigest)
               .certPath(signingCert.getCertPath())
               .signature(signature)

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleFactoryInternal.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleFactoryInternal.java
@@ -17,7 +17,6 @@ package dev.sigstore.bundle;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.JsonFormat;
-import dev.sigstore.ImmutableKeylessSignature;
 import dev.sigstore.KeylessSignature;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.proto.bundle.v1.Bundle;
@@ -210,7 +209,7 @@ class BundleFactoryInternal {
               + " is supported");
     }
     try {
-      return ImmutableKeylessSignature.builder()
+      return KeylessSignature.builder()
           .digest(bundle.getMessageSignature().getMessageDigest().getDigest().toByteArray())
           .certPath(
               toCertPath(


### PR DESCRIPTION
There is a way to make the immutable object more private, but it requires exposing the annotation at runtime. There is a fix for this, but it's not available: https://github.com/immutables/immutables/issues/291