### PR TITLE
Ensure release script and stage-vote-release work

### DIFF
--- a/.github/workflows/tag-and-build-release.yaml
+++ b/.github/workflows/tag-and-build-release.yaml
@@ -58,8 +58,7 @@ jobs:
 
       - name: Build project
         run: |
-          # override the version in gradle.properties
-          ./gradlew clean :sigstore-java:createReleaseBundle -Pversion=${{ github.event.inputs.release_version }}
+          ./gradlew clean :sigstore-java:createReleaseBundle -Pversion=${{ github.event.inputs.release_version }} -Prelease -PskipSign
 
       - name: Hash Artifacts
         id: hash


### PR DESCRIPTION
Together our custom release mechanism and this plugin don't work well. Enable release property so we're not building snapshots and skip signing for now till we can rework release flows.

