### PR TITLE
update to conformance 0.8.0

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Unpack sigstore-java distribution
         run: tar -xvf ${{ github.workspace }}/sigstore-cli/build/distributions/sigstore-cli-*.tar --strip-components 1
 
-      - uses: sigstore/sigstore-conformance@1abc82cdefe80bd907855d8447f903ba8b4918e0 # v0.0.6
+      - uses: sigstore/sigstore-conformance@00922385de455be5ec46288a947044aa44fb0981 # v0.0.8
         with:
           entrypoint: ${{ github.workspace }}/bin/sigstore-cli

--- a/sigstore-cli/src/main/java/dev/sigstore/cli/Sign.java
+++ b/sigstore-cli/src/main/java/dev/sigstore/cli/Sign.java
@@ -28,7 +28,10 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "sign", description = "sign an artifacts")
+@Command(
+    name = "sign",
+    aliases = {"sign-bundle"},
+    description = "sign an artifacts")
 public class Sign implements Callable<Integer> {
 
   @Parameters(arity = "1", paramLabel = "<artifact>", description = "artifact to sign")

--- a/sigstore-cli/src/main/java/dev/sigstore/cli/Verify.java
+++ b/sigstore-cli/src/main/java/dev/sigstore/cli/Verify.java
@@ -89,7 +89,7 @@ public class Verify implements Callable<Integer> {
               .subjectAlternativeName(policy.certificateSan)
               .build());
     }
-    var verificationOptions = verificationOptionsBuilder.isOnline(true).build();
+    var verificationOptions = verificationOptionsBuilder.alwaysUseRemoteRekorEntry(false).build();
 
     var verifier = new KeylessVerifier.Builder().sigstorePublicDefaults().build();
     verifier.verify(

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessVerificationRequest.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessVerificationRequest.java
@@ -26,12 +26,18 @@ public interface KeylessVerificationRequest {
 
   @Default
   default VerificationOptions getVerificationOptions() {
-    return VerificationOptions.builder().isOnline(true).build();
+    return VerificationOptions.builder().alwaysUseRemoteRekorEntry(false).build();
   }
 
   @Immutable
   interface VerificationOptions {
-    boolean isOnline();
+
+    /**
+     * Connect to rekor to obtain a rekor entry for verification. This will ignore the provided
+     * rekor entry in a {@link KeylessSignature}. Verifier may still connect to Rekor to obtain an
+     * entry if no {@link KeylessSignature#getEntry()} is empty.
+     */
+    boolean alwaysUseRemoteRekorEntry();
 
     List<CertificateIdentity> getCertificateIdentities();
 

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -67,7 +67,6 @@ public class KeylessTest {
     verifySigningResult(results);
 
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-
     for (int i = 0; i < results.size(); i++) {
       verifier.verify(
           artifactDigests.get(i),

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
@@ -22,28 +22,11 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class KeylessVerifierTest {
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testVerify(boolean isOnline) throws Exception {
-    var bundleFile =
-        Resources.toString(
-            Resources.getResource("dev/sigstore/samples/bundles/bundle.sigstore"),
-            StandardCharsets.UTF_8);
-    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
-
-    var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-    var verificationReq =
-        KeylessVerificationRequest.builder()
-            .keylessSignature(BundleFactory.readBundle(new StringReader(bundleFile)))
-            .verificationOptions(VerificationOptions.builder().isOnline(isOnline).build())
-            .build();
-    verifier.verify(Path.of(artifact), verificationReq);
-  }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -58,14 +41,14 @@ public class KeylessVerifierTest {
     var verificationReq =
         KeylessVerificationRequest.builder()
             .keylessSignature(BundleFactory.readBundle(new StringReader(bundleFile)))
-            .verificationOptions(VerificationOptions.builder().isOnline(isOnline).build())
+            .verificationOptions(
+                VerificationOptions.builder().alwaysUseRemoteRekorEntry(isOnline).build())
             .build();
     verifier.verify(Path.of(artifact), verificationReq);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void testVerify_mismatchedSet(boolean isOnline) throws Exception {
+  @Test
+  public void testVerify_mismatchedSet() throws Exception {
     // a bundle file where the SET is replaced with a valid SET for another artifact
     var bundleFile =
         Resources.toString(
@@ -78,7 +61,8 @@ public class KeylessVerifierTest {
     var verificationReq =
         KeylessVerificationRequest.builder()
             .keylessSignature(BundleFactory.readBundle(new StringReader(bundleFile)))
-            .verificationOptions(VerificationOptions.builder().isOnline(isOnline).build())
+            .verificationOptions(
+                VerificationOptions.builder().alwaysUseRemoteRekorEntry(false).build())
             .build();
     Assertions.assertThrows(
         KeylessVerificationException.class,


### PR DESCRIPTION
update to conformance 0.8.0 and rework online mode

if no entry is provided during verification, one will always
be requested from remote rekor

if an entry is provided, one will only be requested from rekor
if explicitly instructed to do so. And if a remote entry is
requested, the provided entry is completely ignored.
