### PR TITLE
chore: dokka versions do not always align with Kotlin versions, so use explicit version

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.90")
     implementation("de.thetaphi.forbiddenapis:de.thetaphi.forbiddenapis.gradle.plugin:3.6")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:$embeddedKotlinVersion")
+    implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:1.8.20")
     implementation("com.github.autostyle:com.github.autostyle.gradle.plugin:3.2")
     implementation("net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:3.1.0")
 }


### PR DESCRIPTION
#### Release Note

NONE

#### Documentation

NONE
