### PR TITLE
chore: remove "Signing publications" from the logging output

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/main/kotlin/dev.sigstore.sign.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/main/kotlin/dev.sigstore.sign.gradle.kts
@@ -14,16 +14,13 @@
  * limitations under the License.
  *
  */
-import dev.sigstore.sign.SigstoreSignExtension
-
 plugins {
     id("dev.sigstore.sign-base")
     id("maven-publish")
 }
 
 plugins.withId("publishing") {
-    logger.lifecycle("Signing publications")
-    configure<SigstoreSignExtension> {
-        sign(publications = the<PublishingExtension>().publications)
+    sigstoreSign {
+        sign(publications = publishing.publications)
     }
 }


### PR DESCRIPTION
#### Summary

The message was not adding much, and it was emitted during configuration phase, so it was not even aligned with the actual signing work.


#### Release Note

NONE

#### Documentation

NONE
