### PR TITLE
Custom signing task to ignore sigstore sigs

### DIFF
--- a/build-logic/publishing/src/main/kotlin/build-logic.java-published-library.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.java-published-library.gradle.kts
@@ -1,3 +1,8 @@
+import org.codehaus.groovy.runtime.StringGroovyMethods
+import org.gradle.api.publish.internal.PublicationInternal
+import org.gradle.api.publish.internal.PublicationInternal.DerivedArtifact
+import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal
+
 plugins {
     id("build-logic.repositories")
     id("build-logic.java-library")
@@ -19,4 +24,37 @@ publishing {
     }
 }
 
-signing.sign(publishing.publications["mavenJava"])
+createSignTask(publishing.publications["mavenJava"])
+
+fun createSignTask(publicationToSign: Publication) {
+    val signTaskName = "sign" + StringGroovyMethods.capitalize(publicationToSign.name) + "Publication"
+    if (project.tasks.names.contains(signTaskName)) {
+        throw GradleException("can't create custom sign task (it already exists): $signTaskName")
+    } else {
+        project.tasks.create<Sign>(signTaskName) { // must be create (not register)
+            val task = this
+            task.description = "Signs all artifacts in the 'mavenJava' publication."
+            if (publicationToSign !is MavenPublicationInternal) {
+                throw GradleException("can't configure signing for non-MavenPublication")
+            }
+            publicationToSign.allPublishableArtifacts {
+                if (task.signatureFiles.contains(this.file) || this.file.name.endsWith(".sigstore")) { // or .sigstore.json eventually
+                    return@allPublishableArtifacts
+                }
+                task.dependsOn(this)
+                val signature = Signature(this::getFile, null, task as SignatureSpec, this)
+                task.signatures.add(signature)
+                val derivedArtifact = object : DerivedArtifact {
+                    override fun shouldBePublished(): Boolean {
+                        return task.isEnabled && task.onlyIf.isSatisfiedBy(task)
+                    }
+
+                    override fun create(): File {
+                        return signature.file
+                    }
+                }
+                publicationToSign.addDerivedArtifact(this, derivedArtifact)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is the best I could do for this :shrug: ?

@ljacomet @vlsi wdyt?

It's basically re-implementing parts of the sign extension/task internals to ignore sigstore files. It not fully featured (doesn't handle whenObjectRemoved, etc)