### PR TITLE
feat: remove .sigstore.asc signatures if added by signing plugin

### DIFF
--- a/sigstore-gradle/README.md
+++ b/sigstore-gradle/README.md
@@ -135,6 +135,11 @@ Automatically signs all Maven publications in Sigstore.
 Provides `SigstoreSignFilesTask` task for signing files in Sigstore.
 The plugin adds no tasks by default.
 
+Properties:
+* `dev.sigstore.sign.remove.sigstore.asc` (since 0.6.0, default: `true`). Removes `.sigstore.asc` files from the publication.
+  Sonatype OSSRH supports publishing `.sigstore` signatures, and it does not require `.sigstore.asc` files, so
+  `dev.sigstore.sign` plugin removes them by default. If you need to sign all the files, set this property to `false`.
+
 Extensions:
 * `sigstoreSign`: `dev.sigstore.sign.SigstoreSignExtension`
 

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/RemoveSigstoreAscTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/RemoveSigstoreAscTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sigstore.gradle
+
+import dev.sigstore.testkit.BaseGradleTest
+import dev.sigstore.testkit.TestedGradle
+import dev.sigstore.testkit.TestedSigstoreJava
+import dev.sigstore.testkit.annotations.EnabledIfOidcExists
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
+import org.gradle.util.GradleVersion
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@EnabledIfOidcExists
+class RemoveSigstoreAscTest : BaseGradleTest() {
+    companion object {
+        @JvmStatic
+        fun signingSupportedGradleAndSigstoreJavaVersions(): Iterable<Arguments> =
+            if (isCI) {
+                gradleAndSigstoreJavaVersions()
+            } else {
+                // Find the first version that supports configuration cache for Gradle's signing plugin (8.1+)
+                listOf(
+                    arguments(
+                        TestedGradle(
+                            // Signing plugin supports configuration cache since 8.1
+                            gradleVersions().first { it >= GradleVersion.version("8.1") },
+                            ConfigurationCache.ON
+                        ),
+                        SIGSTORE_JAVA_CURRENT_VERSION
+                    )
+                )
+            }
+
+        @JvmStatic
+        fun oneSigningSupportedGradleAndSigstoreJavaVersions(): Iterable<Arguments> =
+            signingSupportedGradleAndSigstoreJavaVersions().take(1)
+    }
+
+    @ParameterizedTest
+    @MethodSource("signingSupportedGradleAndSigstoreJavaVersions")
+    fun `basic configuration avoids signing sigstore with pgp`(gradle: TestedGradle, sigstoreJava: TestedSigstoreJava) {
+        prepareBuildScripts(gradle, sigstoreJava)
+
+        prepare(gradle.version, "publishAllPublicationsToTmpRepository", "-s")
+            .build()
+
+        assertSoftly {
+            assertSignatures("sigstore-test-1.0.pom")
+            assertSignatures("sigstore-test-1.0-sources.jar")
+            assertSignatures("sigstore-test-1.0.module")
+            assertSignatures("sigstore-test-1.0.pom")
+        }
+
+        if (gradle.configurationCache == ConfigurationCache.ON) {
+            val result = prepare(gradle.version, "publishAllPublicationsToTmpRepository", "-s")
+                .build()
+
+            assertThat(result.output)
+                .contains(
+                    "Configuration cache entry reused",
+                    "7 actionable tasks: 4 executed, 3 up-to-date",
+                )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("oneSigningSupportedGradleAndSigstoreJavaVersions")
+    fun `crossign sigstore with pgp`(gradle: TestedGradle, sigstoreJava: TestedSigstoreJava) {
+        prepareBuildScripts(gradle, sigstoreJava)
+        projectDir.resolve("gradle.properties").toFile().appendText(
+            """
+
+            # By default, dev.sigstore.sign asks Gradle to avoid signing .sigstore as .sigstore.asc
+            # This is an opt-out hatch for those who need .sigstore.asc
+            dev.sigstore.sign.remove.sigstore.asc=false
+            """.trimIndent()
+        )
+        prepare(gradle.version, "publishAllPublicationsToTmpRepository", "-s")
+            .build()
+        assertSoftly {
+            assertSignatures("sigstore-test-1.0.pom", expectSigstoreAsc = true)
+            assertSignatures("sigstore-test-1.0-sources.jar", expectSigstoreAsc = true)
+            assertSignatures("sigstore-test-1.0.module", expectSigstoreAsc = true)
+            assertSignatures("sigstore-test-1.0.pom", expectSigstoreAsc = true)
+        }
+    }
+
+    private fun prepareBuildScripts(gradle: TestedGradle, sigstoreJava: TestedSigstoreJava) {
+        writeBuildGradle(
+            """
+            plugins {
+                id("java")
+                id("signing")
+                id("maven-publish")
+                id("dev.sigstore.sign")
+            }
+            ${declareRepositoryAndDependency(sigstoreJava)}
+
+            group = "dev.sigstore.test"
+            java {
+                withSourcesJar()
+            }
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        groupId = 'dev.sigstore.test'
+                        artifactId = 'sigstore-test'
+                        version = '1.0'
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven {
+                        name = "tmp"
+                        url = layout.buildDirectory.dir("tmp-repo")
+                    }
+                }
+            }
+            signing {
+                useInMemoryPgpKeys(
+                  '''$testOnlySigningKey''',
+                  "testforsigstorejava"
+                )
+                sign(publishing.publications.withType(MavenPublication))
+            }
+            """.trimIndent()
+        )
+        writeSettingsGradle(
+            """
+            rootProject.name = 'sigstore-test'
+            """.trimIndent()
+        )
+        if (gradle.version >= GradleVersion.version("8.1")) {
+            enableConfigurationCache(gradle)
+        }
+    }
+
+    private fun SoftAssertions.assertSignatures(name: String, expectSigstoreAsc: Boolean = false) {
+        assertThat(projectDir.resolve("build/tmp-repo/dev/sigstore/test/sigstore-test/1.0/$name.sigstore"))
+            .describedAs("$name should be signed with Sigstore")
+            .content()
+            .basicSigstoreStructure()
+        assertThat(projectDir.resolve("build/tmp-repo/dev/sigstore/test/sigstore-test/1.0/$name.asc"))
+            .describedAs("$name should be signed with PGP")
+            .isNotEmptyFile()
+        assertThat(projectDir.resolve("build/tmp-repo/dev/sigstore/test/sigstore-test/1.0/$name.asc.sigstore"))
+            .describedAs("$name.asc should NOT be signed with Sigstore")
+            .doesNotExist()
+        assertThat(projectDir.resolve("build/tmp-repo/dev/sigstore/test/sigstore-test/1.0/$name.sigstore.asc"))
+            .apply {
+                if (expectSigstoreAsc) {
+                    describedAs("$name.sigstore should be signed with PGP")
+                    exists()
+                } else {
+                    // We don't want to sign .sigstore files with PGP
+                    describedAs("$name.sigstore should NOT be signed with PGP")
+                    doesNotExist()
+                }
+            }
+    }
+
+    private val testOnlySigningKey = """
+        -----BEGIN PGP PRIVATE KEY BLOCK-----
+
+        lIYEZaDRyxYJKwYBBAHaRw8BAQdAjMi3g07livoPo+se6/+wF7LRv2DDJ6UKVBrp
+        9rugpwj+BwMCDZlNm7zWHTP6ny1jqI5sdTFaEkHRjFhm63Il9qeF7QcSibgAnBO5
+        YK0E4vp8MUQxSAwoOV80mO46a2Ci9hA281lXH6fFTP3qyERXl2/ilrQvVGVzdCBL
+        ZXkgZm9yIFNpZ3N0b3JlIEphdmEgPHNpZ3N0b3JlQGdpdGh1Yi5pbz6IkwQTFgoA
+        OxYhBNejX8GGaAn2Jspav54UgcovliH1BQJloNHLAhsDBQsJCAcCAiICBhUKCQgL
+        AgQWAgMBAh4HAheAAAoJEJ4UgcovliH1YDUBAPE1yBo7i4YgHuHKIGLqkOJqEKE5
+        Jbw8ffyZO6tqud2qAP49liajq/HkdEXgUdA6DySpzLYFtd+F6UlpTQE0TeaLAA==
+        =6fgq
+        -----END PGP PRIVATE KEY BLOCK-----
+    """.trimIndent()
+}

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradle.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradle.kt
@@ -16,10 +16,12 @@
  */
 package dev.sigstore.testkit
 
+import org.gradle.util.GradleVersion
+
 /**
  * Lists Gradle versions and its configuration for backward compatibility testing of Sigstore Gradle plugin.
  */
 data class TestedGradle(
-    val version: String,
+    val version: GradleVersion,
     val configurationCache: BaseGradleTest.ConfigurationCache
 )


### PR DESCRIPTION
#### Summary

By default, the plugin will remove .sigstore.asc.
Project property dev.sigstore.sign.remove.sigstore.asc=false would keep .sigstore.asc files if they are needed

Closes https://github.com/sigstore/sigstore-java/pull/604

#### Release Note

Remove `.sigstore.asc` from Gradle publications.

#### Documentation

NONE