### PR TITLE
test: replace JUnit's Arguments with type safe data classes so parameterized tests are easier to filter

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/SigstoreSignTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/SigstoreSignTest.kt
@@ -18,6 +18,7 @@ package dev.sigstore.gradle
 
 import dev.sigstore.testkit.BaseGradleTest
 import dev.sigstore.testkit.TestedGradle
+import dev.sigstore.testkit.TestedGradleAndSigstoreJava
 import dev.sigstore.testkit.TestedSigstoreJava
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource
 class SigstoreSignTest: BaseGradleTest() {
     @ParameterizedTest
     @MethodSource("gradleAndSigstoreJavaVersions")
-    fun `sign file`(gradle: TestedGradle, sigstoreJava: TestedSigstoreJava) {
+    fun `sign file`(case: TestedGradleAndSigstoreJava) {
         writeBuildGradle(
             """
             import dev.sigstore.sign.tasks.SigstoreSignFilesTask
@@ -36,7 +37,7 @@ class SigstoreSignTest: BaseGradleTest() {
                 id("java")
                 id("dev.sigstore.sign-base")
             }
-            ${declareRepositoryAndDependency(sigstoreJava)}
+            ${declareRepositoryAndDependency(case.sigstoreJava)}
             group = "dev.sigstore.test"
             def helloProps = tasks.register("helloProps", WriteProperties) {
                 outputFile = file("build/helloProps.txt")
@@ -53,15 +54,15 @@ class SigstoreSignTest: BaseGradleTest() {
             rootProject.name = 'sigstore-test'
             """.trimIndent()
         )
-        enableConfigurationCache(gradle)
-        prepare(gradle.version, "signFile", "-s")
+        enableConfigurationCache(case.gradle)
+        prepare(case.gradle.version, "signFile", "-s")
             .build()
         assertThat(projectDir.resolve("build/helloProps.txt.sigstore"))
             .content()
             .basicSigstoreStructure()
 
-        if (gradle.configurationCache == ConfigurationCache.ON) {
-            val result = prepare(gradle.version, "signFile", "-s")
+        if (case.gradle.configurationCache == ConfigurationCache.ON) {
+            val result = prepare(case.gradle.version, "signFile", "-s")
                 .build()
 
             assertThat(result.output)

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/SigstorePublishSignTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/SigstorePublishSignTest.kt
@@ -18,6 +18,7 @@ package dev.sigstore.gradle
 
 import dev.sigstore.testkit.BaseGradleTest
 import dev.sigstore.testkit.TestedGradle
+import dev.sigstore.testkit.TestedGradleAndSigstoreJava
 import dev.sigstore.testkit.TestedSigstoreJava
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource
 class SigstorePublishSignTest : BaseGradleTest() {
     @ParameterizedTest
     @MethodSource("gradleAndSigstoreJavaVersions")
-    fun `sign file`(gradle: TestedGradle, sigstoreJava: TestedSigstoreJava) {
+    fun `sign file`(case: TestedGradleAndSigstoreJava) {
         writeBuildGradle(
             """
             plugins {
@@ -36,7 +37,7 @@ class SigstorePublishSignTest : BaseGradleTest() {
                 id("maven-publish")
                 id("dev.sigstore.sign")
             }
-            ${declareRepositoryAndDependency(sigstoreJava)}
+            ${declareRepositoryAndDependency(case.sigstoreJava)}
 
             group = "dev.sigstore.test"
             java {
@@ -65,8 +66,8 @@ class SigstorePublishSignTest : BaseGradleTest() {
             rootProject.name = 'sigstore-test'
             """.trimIndent()
         )
-        enableConfigurationCache(gradle)
-        prepare(gradle.version, "publishAllPublicationsToTmpRepository", "-s")
+        enableConfigurationCache(case.gradle)
+        prepare(case.gradle.version, "publishAllPublicationsToTmpRepository", "-s")
             .build()
 
         assertThat(projectDir.resolve("build/tmp-repo/dev/sigstore/test/sigstore-test/1.0/sigstore-test-1.0.pom.sigstore"))
@@ -82,8 +83,8 @@ class SigstorePublishSignTest : BaseGradleTest() {
             .content()
             .basicSigstoreStructure()
 
-        if (gradle.configurationCache == ConfigurationCache.ON) {
-            val result = prepare(gradle.version, "publishAllPublicationsToTmpRepository", "-s")
+        if (case.gradle.configurationCache == ConfigurationCache.ON) {
+            val result = prepare(case.gradle.version, "publishAllPublicationsToTmpRepository", "-s")
                 .build()
 
             assertThat(result.output)

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradleAndSigstoreJava.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradleAndSigstoreJava.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package dev.sigstore.testkit
+
+/**
+ * Lists Gradle versions and Sigstore Gradle plugin versions.
+ */
+data class TestedGradleAndSigstoreJava(
+    val gradle: TestedGradle,
+    val sigstoreJava: TestedSigstoreJava,
+)


### PR DESCRIPTION
#### Summary

It should fix failures in https://github.com/sigstore/sigstore-java/actions/runs/7504819762/job/20432729610
The failure was caused by running `version=Gradle 7.3, configurationCache=ON` with `signing` plugin which does not support configuration cache in 7.3

The fix is to exclude such combinations from tests. Let us avoid using JUnit's `Arguments`, `Stream<Arguments>` and so on and we should rather create records as we need them.

#### Release Note

NONE

#### Documentation

NONE
