### PR TITLE
bump version to 0.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 group=dev.sigstore
 # remember to update SigstoreSignExtension.kt when updating this
-version=0.6.0
+version=0.7.0

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -41,7 +41,7 @@ abstract class SigstoreSignExtension(private val project: Project) {
     abstract val sigstoreJavaVersion : Property<String>
 
     init {
-        sigstoreJavaVersion.convention("0.6.0")
+        sigstoreJavaVersion.convention("0.7.0")
         (this as ExtensionAware).extensions.create<OidcClientExtension>(
             "oidcClient",
             project.objects,


### PR DESCRIPTION
we did not release 0.6.0 of the gradle plugin

we'll just do a release now with the new sign and release automatic infrastructure from github actions

