### PR TITLE
Rework signing initialization

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
@@ -150,6 +150,16 @@ public class FulcioVerifier {
     verifySct(fullCertPath);
   }
 
+  public CertPath trimTrustedParent(CertPath signingCertificate)
+      throws FulcioVerificationException, CertificateException {
+    for (var ca : cas) {
+      if (Certificates.containsParent(signingCertificate, ca.getCertPath())) {
+        return Certificates.trimParent(signingCertificate, ca.getCertPath());
+      }
+    }
+    throw new FulcioVerificationException("Certificate does not chain to trusted roots");
+  }
+
   /**
    * Find a valid cert path that chains back up to the trusted root certs and reconstruct a
    * certificate path combining the provided un-trusted certs and a known set of trusted and

--- a/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioClientTest.java
@@ -23,19 +23,11 @@ import dev.sigstore.testing.FakeCTLogServer;
 import dev.sigstore.testing.FulcioWrapper;
 import dev.sigstore.testing.MockOAuth2ServerExtension;
 import dev.sigstore.testing.grpc.GrpcTypes;
-import dev.sigstore.trustroot.CertificateAuthority;
-import dev.sigstore.trustroot.ImmutableCertificateAuthority;
-import dev.sigstore.trustroot.ImmutableValidFor;
-import dev.sigstore.trustroot.Subject;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
-import java.time.Instant;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 
 public class FulcioClientTest {
 
@@ -58,8 +50,7 @@ public class FulcioClientTest {
     var client =
         FulcioClient.builder()
             .setHttpParams(ImmutableHttpParams.builder().allowInsecureConnections(true).build())
-            .setCertificateAuthority(
-                createCA(fulcioWrapper.getGrpcURI2(), fulcioWrapper.getTrustBundle()))
+            .setUri(fulcioWrapper.getGrpcURI2())
             .build();
 
     var sc = client.signingCertificate(cReq);
@@ -89,21 +80,11 @@ public class FulcioClientTest {
     var client =
         FulcioClient.builder()
             .setHttpParams(ImmutableHttpParams.builder().allowInsecureConnections(true).build())
-            .setCertificateAuthority(
-                createCA(fulcioWrapper.getGrpcURI2(), fulcioWrapper.getTrustBundle()))
+            .setUri(fulcioWrapper.getGrpcURI2())
             .build();
     var ex =
         Assertions.assertThrows(CertificateException.class, () -> client.signingCertificate(cReq));
     Assertions.assertEquals(ex.getMessage(), "Detached SCTs are not supported");
-  }
-
-  private CertificateAuthority createCA(URI uri, CertPath trustBundle) {
-    return ImmutableCertificateAuthority.builder()
-        .uri(uri)
-        .certPath(trustBundle)
-        .subject(Mockito.mock(Subject.class))
-        .validFor(ImmutableValidFor.builder().start(Instant.EPOCH).build())
-        .build();
   }
 
   @Test

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientTest.java
@@ -23,9 +23,6 @@ import com.google.common.collect.ImmutableList;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.testing.CertGenerator;
-import dev.sigstore.trustroot.ImmutableTransparencyLog;
-import dev.sigstore.trustroot.LogId;
-import dev.sigstore.trustroot.PublicKey;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -44,7 +41,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class RekorClientTest {
 
@@ -55,16 +51,7 @@ public class RekorClientTest {
   public void setupClient() throws URISyntaxException {
     // this tests directly against rekor in staging, it's a bit hard to bring up a rekor instance
     // without docker compose.
-    client =
-        RekorClient.builder()
-            .setTransparencyLog(
-                ImmutableTransparencyLog.builder()
-                    .baseUrl(URI.create(REKOR_URL))
-                    .hashAlgorithm("ignored")
-                    .publicKey(Mockito.mock(PublicKey.class))
-                    .logId(Mockito.mock(LogId.class))
-                    .build())
-            .build();
+    client = RekorClient.builder().setUri(URI.create(REKOR_URL)).build();
   }
 
   @Test


### PR DESCRIPTION
Make the signing clients configured with URIs instead of objects from the trusted_root.json. This code still uses the URIs from the trusted_root.json to populate those values, but this is a setup towards using the SigningConfiguration type that is coming in the future.
