### PR TITLE
Generate java client for proto at build

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -20,13 +20,11 @@ dependencies {
 
     implementation("io.github.erdtman:java-json-canonicalization:1.1")
 
-    implementation("dev.sigstore:protobuf-specs:0.3.0") {
-        because("It generates Sigstore Bundle file")
-    }
-    implementation(platform("com.google.protobuf:protobuf-bom:3.25.3"))
-    implementation("com.google.protobuf:protobuf-java-util") {
-        because("It converts protobuf to json")
-    }
+    protobuf("dev.sigstore:protobuf-specs:0.3.0")
+    protobuf("com.google.api.grpc:proto-google-common-protos:2.37.1")
+
+    implementation(platform("com.google.protobuf:protobuf-bom:4.26.1"))
+    implementation("com.google.protobuf:protobuf-java-util")
 
     // grpc deps
     implementation(platform("io.grpc:grpc-bom:1.62.2"))
@@ -64,7 +62,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:4.26.1"
     }
     plugins {
         id("grpc") {


### PR DESCRIPTION
Stop using pre-generated protobuf client libraries, just use the proto files directly when generating clients. This allows us to update proto-gen versions without worrying about conflicts (We were geneating client for fulcio.proto locally while using pre generated proto clients for protobuf-spec)

A followup to this will be to remove the generator from https://github.com/sigstore/protobuf-specs and only publish the .proto files in a jar.

Also supersedes #669