### PR TITLE
Update release-sigstore-gradle-plugin-from-tag.yaml

### DIFF
--- a/.github/workflows/release-sigstore-gradle-plugin-from-tag.yaml
+++ b/.github/workflows/release-sigstore-gradle-plugin-from-tag.yaml
@@ -56,16 +56,3 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-
-  create-release-on-github:
-    runs-on: ubuntu-latest
-    needs: [build]
-    permissions:
-      contents: write
-    steps:
-      - name: Create release
-        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}-gradle
-          body: "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for more details."


### PR DESCRIPTION
Creating a release was just overwriting the library release. We don't need to do this now, but we can add it back later if we need to append something.
