### PR TITLE
Add buildinfo at compile time

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.build-info.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.build-info.gradle.kts
@@ -1,0 +1,14 @@
+import buildlogic.BuildInfoTask
+
+plugins {
+    java
+}
+
+val generateBuildInfo by tasks.registering(BuildInfoTask::class) {
+    version.set(project.version.toString())
+    genDir.set(project.layout.buildDirectory.dir("generated/buildinfo"))
+}
+
+sourceSets.main {
+    java.srcDir(generateBuildInfo)
+}

--- a/build-logic/jvm/src/main/kotlin/buildlogic/BuildInfoTask.kt
+++ b/build-logic/jvm/src/main/kotlin/buildlogic/BuildInfoTask.kt
@@ -1,0 +1,37 @@
+package buildlogic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class BuildInfoTask : DefaultTask() {
+    @get:Input
+    abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val version: Property<String>
+
+    @get:OutputDirectory
+    abstract val genDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        val output = """
+            |package ${packageName.get()};
+            |
+            |public class BuildInfo {
+            |  public static final String VERSION = "${version.get()}";
+            |}
+        """.trimMargin()
+        val outputPath = genDir.file(packageName.get().replace(".", "/").plus("/BuildInfo.java")).get().asFile
+        outputPath.parentFile.mkdirs()
+        outputPath.writeText(output)
+    }
+}

--- a/build-logic/jvm/src/main/kotlin/buildlogic/BuildInfoTask.kt
+++ b/build-logic/jvm/src/main/kotlin/buildlogic/BuildInfoTask.kt
@@ -24,12 +24,12 @@ abstract class BuildInfoTask : DefaultTask() {
     @TaskAction
     fun run() {
         val output = """
-            |package ${packageName.get()};
-            |
-            |public class BuildInfo {
-            |  public static final String VERSION = "${version.get()}";
-            |}
-        """.trimMargin()
+            package ${packageName.get()};
+
+            public class BuildInfo {
+              public static final String VERSION = "${version.get()}";
+            }
+        """.trimIndent()
         val outputPath = genDir.file(packageName.get().replace(".", "/").plus("/BuildInfo.java")).get().asFile
         outputPath.parentFile.mkdirs()
         outputPath.writeText(output)

--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.id
 plugins {
     id("build-logic.java-published-library")
     id("build-logic.test-junit5")
+    id("build-logic.build-info")
     id("org.jsonschema2dataclass") version "5.0.0"
     id("com.google.protobuf") version "0.9.4"
 }
@@ -119,4 +120,8 @@ jsonSchema2Pojo {
 // TODO: keep until these code gen plugins explicitly declare dependencies
 tasks.named("sourcesJar") {
     dependsOn("generateJsonSchema2DataClassConfigRekor")
+}
+
+tasks.generateBuildInfo {
+    packageName.set("dev.sigstore.buildinfo")
 }

--- a/sigstore-java/src/main/java/dev/sigstore/http/HttpParams.java
+++ b/sigstore-java/src/main/java/dev/sigstore/http/HttpParams.java
@@ -16,6 +16,7 @@
 package dev.sigstore.http;
 
 import com.google.api.client.util.Preconditions;
+import dev.sigstore.buildinfo.BuildInfo;
 import org.immutables.value.Value;
 
 /**
@@ -24,7 +25,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 public abstract class HttpParams {
-  static final String DEFAULT_USER_AGENT = "sigstoreJavaClient/0.0.1";
+  static final String DEFAULT_USER_AGENT = "sigstoreJavaClient/" + BuildInfo.VERSION;
   static final int DEFAULT_TIMEOUT = 60;
   static final boolean DEFAULT_ALLOW_INSECURE_CONNECTIONS = false;
 


### PR DESCRIPTION
Injects build info, which appears to be somewhat more portable that reading the jar manifest?