### PR TITLE
chore: avoid generating protobuf(proto-google-common-protos) protobufs every time

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -21,7 +21,9 @@ dependencies {
     implementation("io.github.erdtman:java-json-canonicalization:1.1")
 
     protobuf("dev.sigstore:protobuf-specs:0.3.2")
-    protobuf("com.google.api.grpc:proto-google-common-protos:2.39.1")
+    compileProtoPath("com.google.api.grpc:proto-google-common-protos:2.39.1") {
+        because("fulcio.proto imports google/api protos")
+    }
 
     implementation(platform("com.google.protobuf:protobuf-bom:4.26.1"))
     implementation("com.google.protobuf:protobuf-java-util")


### PR DESCRIPTION
`protobuf(...)` causes protoc to generate code for the listed proto files `compileProtoPath` adds the listed artifacts on the "include path", so we can reference third-party definitions and generate code for our proto files only.

Note: `com.google.protobuf` searches both `compileProtoPath` and implementation dependencies for .proto files.
`io.grpc:grpc-protobuf` already depends on `proto-google-common-protos`, so the build would work even without explicit dependency. However, we import `google/api` protos, so it would be nice to explicitly mention the used dependencies even though they are present as transitive.
