### PR TITLE
Update gpg plugin out of band

### DIFF
--- a/sigstore-maven-plugin/build.gradle.kts
+++ b/sigstore-maven-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
     implementation(project(":sigstore-java"))
     implementation("org.bouncycastle:bcutil-jdk18on:1.78.1")
-    implementation("org.apache.maven.plugins:maven-gpg-plugin:3.1.0")
+    implementation("org.apache.maven.plugins:maven-gpg-plugin:3.2.4")
 
     testImplementation("org.apache.maven.shared:maven-verifier:1.8.0")
 


### PR DESCRIPTION
Sonatype threw some warnings. We haven't run renovate since merging in the maven plugin.