### PR TITLE
Gradle plugin: Replace findProperty with Isolated Project compatible …

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -84,7 +84,7 @@ abstract class SigstoreSignExtension(private val project: Project) {
         }
 
         val removeSigstoreAsc =
-            project.findProperty("dev.sigstore.sign.remove.sigstore.json.asc")?.toString()?.toBoolean() != false
+            project.providers.gradleProperty("dev.sigstore.sign.remove.sigstore.json.asc").map { it.toBoolean() }.orNull != false
 
         val publicationName = publication.name
 

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -84,7 +84,7 @@ abstract class SigstoreSignExtension(private val project: Project) {
         }
 
         val removeSigstoreAsc =
-            project.providers.gradleProperty("dev.sigstore.sign.remove.sigstore.json.asc").map { it.toBoolean() }.orNull != false
+            project.providers.gradleProperty("dev.sigstore.sign.remove.sigstore.json.asc").orNull?.toBoolean() != false
 
         val publicationName = publication.name
 

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/OidcDslTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/OidcDslTest.kt
@@ -46,6 +46,7 @@ class OidcDslTest: BaseGradleTest() {
             """.trimIndent()
         )
         enableConfigurationCache(gradle)
+        enableProjectIsolation(gradle)
         prepare(gradle.version, "printConfig", "-s")
             .build()
     }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/SigstoreSignTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/SigstoreSignTest.kt
@@ -55,6 +55,7 @@ class SigstoreSignTest: BaseGradleTest() {
             """.trimIndent()
         )
         enableConfigurationCache(case.gradle)
+        enableProjectIsolation(case.gradle)
         prepare(case.gradle.version, "signFile", "-s")
             .build()
         assertThat(projectDir.resolve("build/helloProps.txt.sigstore.json"))

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/RemoveSigstoreAscTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/RemoveSigstoreAscTest.kt
@@ -41,7 +41,7 @@ class RemoveSigstoreAscTest : BaseGradleTest() {
                     // Gradle < 8.1 + configuration cache=on which is incompatible with signing plugin.
                     listOf(
                         TestedGradleAndSigstoreJava(
-                            TestedGradle(GradleVersion.version("8.1"), ConfigurationCache.OFF),
+                            TestedGradle(GradleVersion.version("8.1"), ConfigurationCache.OFF, ProjectIsolation.OFF),
                             SIGSTORE_JAVA_CURRENT_VERSION
                         )
                     )
@@ -147,6 +147,7 @@ class RemoveSigstoreAscTest : BaseGradleTest() {
             """.trimIndent()
         )
         enableConfigurationCache(case.gradle)
+        enableProjectIsolation(case.gradle)
     }
 
     private fun SoftAssertions.assertSignatures(name: String, expectSigstoreAsc: Boolean = false) {

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/SigstorePublishSignTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/SigstorePublishSignTest.kt
@@ -65,6 +65,7 @@ class SigstorePublishSignTest : BaseGradleTest() {
             """.trimIndent()
         )
         enableConfigurationCache(case.gradle)
+        enableProjectIsolation(case.gradle)
         prepare(case.gradle.version, "publishAllPublicationsToTmpRepository", "-s")
             .build()
 

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradle.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/TestedGradle.kt
@@ -23,5 +23,6 @@ import org.gradle.util.GradleVersion
  */
 data class TestedGradle(
     val version: GradleVersion,
-    val configurationCache: BaseGradleTest.ConfigurationCache
+    val configurationCache: BaseGradleTest.ConfigurationCache,
+    val projectIsolation: BaseGradleTest.ProjectIsolation,
 )


### PR DESCRIPTION
…api gradleProperty

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
`findProperty` is not compatible with Gradle Isolated Projects, but `providers.gradleProperty` is. To test this change, you need an Isolated Projects compatible build, eg plain java library.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Add support for Gradle Isolated Projects.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
