### PR TITLE
adjustments to tuf client for conformance

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -153,7 +153,7 @@ public class SigstoreTufClient {
   public void forceUpdate()
       throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException,
           CertificateException {
-    updater.update();
+    updater.downloadTargets(TRUST_ROOT_FILENAME);
     lastUpdate = Instant.now();
     var trustedRootBuilder = TrustedRoot.newBuilder();
     JsonFormat.parser()

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TargetMetadataMissingException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TargetMetadataMissingException.java
@@ -18,6 +18,10 @@ package dev.sigstore.tuf;
 import java.util.Locale;
 
 public class TargetMetadataMissingException extends TufException {
+  public TargetMetadataMissingException() {
+    super("No target metadata were found");
+  }
+
   public TargetMetadataMissingException(String targetName) {
     super(String.format(Locale.ROOT, "The target (%s) has no metadata", targetName));
   }

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/SigstoreTufClientTest.java
@@ -72,7 +72,8 @@ class SigstoreTufClientTest {
     client.update();
     Thread.sleep(3000);
     client.update();
-    Mockito.verify(mockUpdater, Mockito.times(2)).update();
+    Mockito.verify(mockUpdater, Mockito.times(2))
+        .downloadTargets(SigstoreTufClient.TRUST_ROOT_FILENAME);
   }
 
   @Test
@@ -82,7 +83,8 @@ class SigstoreTufClientTest {
 
     client.update();
     client.update();
-    Mockito.verify(mockUpdater, Mockito.times(1)).update();
+    Mockito.verify(mockUpdater, Mockito.times(1))
+        .downloadTargets(SigstoreTufClient.TRUST_ROOT_FILENAME);
   }
 
   private static Updater mockUpdater() throws IOException {

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
@@ -590,7 +590,9 @@ class UpdaterTest {
     var targets = updater.updateTargets(root, snapshot);
     assertThrows(
         FileNotFoundException.class,
-        () -> updater.downloadTargets(targets),
+        () ->
+            updater.downloadTargets(
+                targets.getSignedMeta().getTargets().keySet().toArray(new String[0])),
         "the target file for download should be missing from the repo and cause an exception.");
   }
 
@@ -611,7 +613,9 @@ class UpdaterTest {
     var targets = updater.updateTargets(root, snapshot);
     assertThrows(
         FileExceedsMaxLengthException.class,
-        () -> updater.downloadTargets(targets),
+        () ->
+            updater.downloadTargets(
+                targets.getSignedMeta().getTargets().keySet().toArray(new String[0])),
         "The target file is expected to not match the length specified in targets.json target data.");
   }
 
@@ -632,7 +636,9 @@ class UpdaterTest {
     var targets = updater.updateTargets(root, snapshot);
     assertThrows(
         InvalidHashesException.class,
-        () -> updater.downloadTargets(targets),
+        () ->
+            updater.downloadTargets(
+                targets.getSignedMeta().getTargets().keySet().toArray(new String[0])),
         "The target file has been modified and should not match the expected hash");
   }
 
@@ -653,7 +659,7 @@ class UpdaterTest {
     var timestamp = updater.updateTimestamp(root);
     var snapshot = updater.updateSnapshot(root, timestamp.get());
     var targets = updater.updateTargets(root, snapshot);
-    updater.downloadTargets(targets);
+    updater.downloadTargets(targets.getSignedMeta().getTargets().keySet().toArray(new String[0]));
     assertTrue(updater.getLocalStore().getTargetFile("test.txt") != null);
     assertTrue(updater.getLocalStore().getTargetFile("test.txt.v2") != null);
     assertTrue(updater.getLocalStore().getTargetFile("test2.txt") != null);
@@ -681,7 +687,10 @@ class UpdaterTest {
     var timestamp = updater.updateTimestamp(root);
     var snapshot = updater.updateSnapshot(root, timestamp.get());
     var targets = updater.updateTargets(root, snapshot);
-    assertDoesNotThrow(() -> updater.downloadTargets(targets));
+    assertDoesNotThrow(
+        () ->
+            updater.downloadTargets(
+                targets.getSignedMeta().getTargets().keySet().toArray(new String[0])));
   }
 
   // End to end sanity test on the actual prod sigstore repo.
@@ -719,6 +728,9 @@ class UpdaterTest {
     Optional<Targets> targets = localStore.loadTargets();
     assertTrue(targets.isPresent(), "a list of targets should be available in the store");
     Map<String, TargetMeta.TargetData> targetsData = targets.get().getSignedMeta().getTargets();
+    assertDoesNotThrow(
+        () -> updater.downloadTargets(targetsData.keySet().toArray(new String[0])),
+        "all targets should be downloadable");
     for (String file : targetsData.keySet()) {
       TargetMeta.TargetData fileData = targetsData.get(file);
       byte[] fileBytes = localStore.getTargetFile(file);


### PR DESCRIPTION
This doesn't really bring us in line with how python-tuf works, but it does allow us to interface with the tuf-conformance suite a little better.

still todo:
- add cli for conformance
- maybe impl delegated targets