### PR TITLE
Separate meta fetching from target fetching

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Fetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Fetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Sigstore Authors.
+ * Copyright 2024 The Sigstore Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,12 @@
  */
 package dev.sigstore.tuf;
 
-import java.net.URL;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import java.io.IOException;
 
-class HttpMetaFetcherTest {
+public interface Fetcher {
 
-  @ParameterizedTest
-  @CsvSource({"http://example.com", "http://example.com/"})
-  public void newFetcher_urlNoTrailingSlash(String url) throws Exception {
-    var fetcher = HttpMetaFetcher.newFetcher(new URL(url));
-    Assertions.assertEquals("http://example.com/", fetcher.getSource());
-  }
+  String getSource();
+
+  byte[] fetchResource(String filename, int maxLength)
+      throws IOException, FileExceedsMaxLengthException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -53,7 +53,7 @@ public class FileSystemTufStore implements MutableTufStore {
     return newFileSystemStore(repoBaseDir, defaultTargetsCache);
   }
 
-  static MutableTufStore newFileSystemStore(Path repoBaseDir, Path targetsCache) {
+  public static MutableTufStore newFileSystemStore(Path repoBaseDir, Path targetsCache) {
     if (!Files.isDirectory(repoBaseDir)) {
       throw new IllegalArgumentException(repoBaseDir + " must be a file system directory.");
     }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/HttpFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/HttpFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Sigstore Authors.
+ * Copyright 2024 The Sigstore Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,83 +15,33 @@
  */
 package dev.sigstore.tuf;
 
-import static dev.sigstore.json.GsonSupplier.GSON;
-
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.json.gson.GsonFactory;
-import com.google.common.base.Preconditions;
 import dev.sigstore.http.HttpClients;
 import dev.sigstore.http.ImmutableHttpParams;
-import dev.sigstore.tuf.model.Root;
-import dev.sigstore.tuf.model.SignedTufMeta;
-import dev.sigstore.tuf.model.TufMeta;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
-import java.util.Optional;
-import javax.annotation.Nullable;
 
-public class HttpMetaFetcher implements MetaFetcher {
+public class HttpFetcher implements Fetcher {
 
-  private static final int MAX_META_BYTES = 99 * 1024; // 99 KB
   private final URL mirror;
 
-  HttpMetaFetcher(URL mirror) {
+  private HttpFetcher(URL mirror) {
     this.mirror = mirror;
   }
 
-  public static HttpMetaFetcher newFetcher(URL mirror) throws MalformedURLException {
+  public static HttpFetcher newFetcher(URL mirror) throws MalformedURLException {
     if (mirror.toString().endsWith("/")) {
-      return new HttpMetaFetcher(mirror);
+      return new HttpFetcher(mirror);
     }
-    return new HttpMetaFetcher(new URL(mirror.toExternalForm() + "/"));
+    return new HttpFetcher(new URL(mirror.toExternalForm() + "/"));
   }
 
   @Override
   public String getSource() {
     return mirror.toString();
-  }
-
-  @Override
-  public Optional<MetaFetchResult<Root>> getRootAtVersion(int version)
-      throws IOException, FileExceedsMaxLengthException {
-    String versionFileName = version + ".root.json";
-    return getMeta(versionFileName, Root.class, null);
-  }
-
-  @Override
-  public <T extends SignedTufMeta<? extends TufMeta>> Optional<MetaFetchResult<T>> getMeta(
-      String role, Class<T> t) throws IOException, FileExceedsMaxLengthException {
-    return getMeta(getFileName(role, null), t, null);
-  }
-
-  @Override
-  public <T extends SignedTufMeta<? extends TufMeta>> Optional<MetaFetchResult<T>> getMeta(
-      String role, int version, Class<T> t, Integer maxSize)
-      throws IOException, FileExceedsMaxLengthException {
-    Preconditions.checkArgument(version > 0, "version should be positive, got: %s", version);
-    return getMeta(getFileName(role, version), t, maxSize);
-  }
-
-  private static String getFileName(String role, @Nullable Integer version) {
-    return version == null
-        ? role + ".json"
-        : String.format(Locale.ROOT, "%d.%s.json", version, role);
-  }
-
-  <T extends SignedTufMeta> Optional<MetaFetchResult<T>> getMeta(
-      String filename, Class<T> t, Integer maxSize)
-      throws IOException, FileExceedsMaxLengthException {
-    byte[] roleBytes = fetchResource(filename, maxSize == null ? MAX_META_BYTES : maxSize);
-    if (roleBytes == null) {
-      return Optional.empty();
-    }
-    var result =
-        new MetaFetchResult<T>(
-            roleBytes, GSON.get().fromJson(new String(roleBytes, StandardCharsets.UTF_8), t));
-    return Optional.of(result);
   }
 
   @Override

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/HttpFetcherTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/HttpFetcherTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.tuf;
+
+import java.net.URL;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class HttpFetcherTest {
+
+  @ParameterizedTest
+  @CsvSource({"http://example.com", "http://example.com/"})
+  public void newFetcher_urlNoTrailingSlash(String url) throws Exception {
+    var fetcher = HttpFetcher.newFetcher(new URL(url));
+    Assertions.assertEquals("http://example.com/", fetcher.getSource());
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
@@ -1048,7 +1048,8 @@ class UpdaterTest {
     return Updater.builder()
         .setClock(Clock.fixed(Instant.parse(time), ZoneOffset.UTC))
         .setVerifiers(Verifiers::newVerifier)
-        .setFetcher(HttpMetaFetcher.newFetcher(new URL(remoteUrl)))
+        .setMetaFetcher(MetaFetcher.newFetcher(HttpFetcher.newFetcher(new URL(remoteUrl))))
+        .setTargetFetcher(HttpFetcher.newFetcher(new URL(remoteUrl + "targets/")))
         .setTrustedRootPath(RootProvider.fromFile(trustedRootFile))
         .setLocalStore(FileSystemTufStore.newFileSystemStore(localStore))
         .build();


### PR DESCRIPTION
Part of adjustments for conformance. Allows fetching meta and targets from different locations.