### PR TITLE
only run errorpone in java 17+

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -4,11 +4,11 @@ plugins {
     java
 }
 
-if (!project.hasProperty("skipErrorprone")) {
+if (!project.hasProperty("skipErrorprone") && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     apply(plugin = "net.ltgt.errorprone")
 
     dependencies {
-        "errorprone"("com.google.errorprone:error_prone_core:2.31.0")
+        "errorprone"("com.google.errorprone:error_prone_core:2.35.1")
         "annotationProcessor"("com.google.guava:guava-beta-checker:1.0")
     }
 


### PR DESCRIPTION
might be strange for devs working with java11, but our CI will catch it anyway
