### PR TITLE
Update tuf updater api surface

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Root.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Root.java
@@ -24,6 +24,7 @@ import org.immutables.value.Value.Derived;
 @Value.Immutable
 public interface Root extends SignedTufMeta<RootMeta> {
   @Override
+  @Gson.Ignore
   @Derived
   default RootMeta getSignedMeta() {
     return getSignedMeta(RootMeta.class);

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/SignedTufMeta.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/SignedTufMeta.java
@@ -38,6 +38,7 @@ public interface SignedTufMeta<T extends TufMeta> {
 
   /** An internal helper to translate raw signed json to a useable type. */
   @Derived
+  @Gson.Ignore
   default T getSignedMeta(Class<T> type) {
     return GsonSupplier.GSON.get().fromJson(getRawSignedMeta(), type);
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Snapshot.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Snapshot.java
@@ -25,6 +25,7 @@ import org.immutables.value.Value.Derived;
 public interface Snapshot extends SignedTufMeta<SnapshotMeta> {
   @Override
   @Derived
+  @Gson.Ignore
   default SnapshotMeta getSignedMeta() {
     return getSignedMeta(SnapshotMeta.class);
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/SnapshotMeta.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/SnapshotMeta.java
@@ -59,6 +59,7 @@ public interface SnapshotMeta extends TufMeta {
 
     /** The length in bytes of the given target's metadata, or a default if not present */
     @Derived
+    @Gson.Ignore
     default Integer getLengthOrDefault() {
       return getLength().orElse(DEFAULT_MAX_LENGTH);
     }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Targets.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Targets.java
@@ -25,6 +25,7 @@ import org.immutables.value.Value.Derived;
 public interface Targets extends SignedTufMeta<TargetMeta> {
   @Override
   @Derived
+  @Gson.Ignore
   default TargetMeta getSignedMeta() {
     return getSignedMeta(TargetMeta.class);
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
@@ -26,6 +26,7 @@ public interface Timestamp extends SignedTufMeta<TimestampMeta> {
 
   @Override
   @Derived
+  @Gson.Ignore
   default TimestampMeta getSignedMeta() {
     return getSignedMeta(TimestampMeta.class);
   }


### PR DESCRIPTION
- Expose updateMeta and downloadTarget for conformance
- Also don't persist derived attributes in TufMeta
