### PR TITLE
More tuf updates for conformance

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaStore.java
@@ -15,7 +15,6 @@
  */
 package dev.sigstore.tuf;
 
-import dev.sigstore.tuf.model.Root;
 import dev.sigstore.tuf.model.SignedTufMeta;
 import dev.sigstore.tuf.model.TufMeta;
 import java.io.IOException;
@@ -31,8 +30,7 @@ public interface MetaStore extends MetaReader {
   String getIdentifier();
 
   /**
-   * Generic method to store one of the {@link SignedTufMeta} resources in the local tuf store. Do
-   * not use for Root role, use {@link #writeRoot(Root)} instead.
+   * Generic method to store one of the {@link SignedTufMeta} resources in the local tuf store.
    *
    * @param roleName the name of the role
    * @param meta the metadata to store
@@ -41,26 +39,13 @@ public interface MetaStore extends MetaReader {
   void writeMeta(String roleName, SignedTufMeta<? extends TufMeta> meta) throws IOException;
 
   /**
-   * Once you have ascertained that your root is trustworthy use this method to persist it to your
-   * local store. This will usually only be called with a root loaded statically from a bundled
-   * trusted root, or after the successful verification of an updated root from a mirror.
-   *
-   * @param root a root that has been proven trustworthy by the client
-   * @throws IOException since some implementations may persist the root to disk or over the network
-   *     we throw {@code IOException} in case of IO error.
-   * @see <a
-   *     href="https://theupdateframework.github.io/specification/latest/#detailed-client-workflow">5.3.8</a>
-   */
-  void writeRoot(Root root) throws IOException;
-
-  /**
-   * This clears out the snapshot and timestamp metadata from the store, as required when snapshot
-   * or timestamp verification keys have changed as a result of a root update.
+   * Generic method to remove meta, useful when keys rotated in root. Deletion is not optional,
+   * implementers must ensure meta is removed from the storage medium.
    *
    * @throws IOException implementations that read/write IO to clear the data may throw {@code
    *     IOException}
    * @see <a
    *     href="https://theupdateframework.github.io/specification/latest/#detailed-client-workflow">5.3.11</a>
    */
-  void clearMetaDueToKeyRotation() throws IOException;
+  void clearMeta(String role) throws IOException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/PassthroughCacheMetaStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/PassthroughCacheMetaStore.java
@@ -15,14 +15,11 @@
  */
 package dev.sigstore.tuf;
 
-import dev.sigstore.tuf.model.Root;
-import dev.sigstore.tuf.model.RootRole;
 import dev.sigstore.tuf.model.SignedTufMeta;
 import dev.sigstore.tuf.model.TufMeta;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 /** An in memory cache that will pass through to a provided local tuf store. */
@@ -45,13 +42,6 @@ public class PassthroughCacheMetaStore implements MetaReader, MetaStore {
   }
 
   @Override
-  public void writeRoot(Root root) throws IOException {
-    // call writeRoot instead of generic writeMeta because it may do extra work when storing on disk
-    localStore.writeRoot(root);
-    cache.put(RootRole.ROOT, root);
-  }
-
-  @Override
   @SuppressWarnings("unchecked")
   public <T extends SignedTufMeta<? extends TufMeta>> Optional<T> readMeta(
       String roleName, Class<T> tClass) throws IOException {
@@ -69,17 +59,13 @@ public class PassthroughCacheMetaStore implements MetaReader, MetaStore {
 
   @Override
   public void writeMeta(String roleName, SignedTufMeta<? extends TufMeta> meta) throws IOException {
-    if (Objects.equals(roleName, RootRole.ROOT)) {
-      throw new IllegalArgumentException("Calling writeMeta on root instead of writeRoot");
-    }
     localStore.writeMeta(roleName, meta);
     cache.put(roleName, meta);
   }
 
   @Override
-  public void clearMetaDueToKeyRotation() throws IOException {
-    localStore.clearMetaDueToKeyRotation();
-    cache.remove(RootRole.TIMESTAMP);
-    cache.remove(RootRole.SNAPSHOT);
+  public void clearMeta(String role) throws IOException {
+    localStore.clearMeta(role);
+    cache.remove(role);
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TrustedMetaStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TrustedMetaStore.java
@@ -70,7 +70,7 @@ public class TrustedMetaStore {
   }
 
   public void setRoot(Root root) throws IOException {
-    metaStore.writeRoot(root);
+    metaStore.writeMeta(RootRole.ROOT, root);
   }
 
   public Root getRoot() throws IOException {
@@ -118,6 +118,7 @@ public class TrustedMetaStore {
   }
 
   public void clearMetaDueToKeyRotation() throws IOException {
-    metaStore.clearMetaDueToKeyRotation();
+    metaStore.clearMeta(RootRole.TIMESTAMP);
+    metaStore.clearMeta(RootRole.SNAPSHOT);
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Root.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Root.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf.model;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
@@ -28,5 +29,10 @@ public interface Root extends SignedTufMeta<RootMeta> {
   @Derived
   default RootMeta getSignedMeta() {
     return getSignedMeta(RootMeta.class);
+  }
+
+  @Value.Check
+  default void checkType() {
+    Preconditions.checkState(getSignedMeta().getType().equals("root"));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Snapshot.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Snapshot.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf.model;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
@@ -28,5 +29,10 @@ public interface Snapshot extends SignedTufMeta<SnapshotMeta> {
   @Gson.Ignore
   default SnapshotMeta getSignedMeta() {
     return getSignedMeta(SnapshotMeta.class);
+  }
+
+  @Value.Check
+  default void checkType() {
+    Preconditions.checkState(getSignedMeta().getType().equals("snapshot"));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Targets.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Targets.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf.model;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
@@ -28,5 +29,10 @@ public interface Targets extends SignedTufMeta<TargetMeta> {
   @Gson.Ignore
   default TargetMeta getSignedMeta() {
     return getSignedMeta(TargetMeta.class);
+  }
+
+  @Value.Check
+  default void checkType() {
+    Preconditions.checkState(getSignedMeta().getType().equals("targets"));
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf.model;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Derived;
@@ -29,5 +30,10 @@ public interface Timestamp extends SignedTufMeta<TimestampMeta> {
   @Gson.Ignore
   default TimestampMeta getSignedMeta() {
     return getSignedMeta(TimestampMeta.class);
+  }
+
+  @Value.Check
+  default void checkType() {
+    Preconditions.checkState(getSignedMeta().getType().equals("timestamp"));
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
@@ -43,33 +43,24 @@ class FileSystemTufStoreTest {
   }
 
   @Test
-  void setTrustedRoot_noPrevious(@TempDir Path repoBase) throws IOException {
+  void writeMeta(@TempDir Path repoBase) throws IOException {
     FileSystemTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertFalse(repoBase.resolve("root.json").toFile().exists());
-    tufStore.writeRoot(TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
+    tufStore.writeMeta(
+        RootRole.ROOT, TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
     assertEquals(2, repoBase.toFile().list().length, "Expect 2: root.json plus the /targets dir.");
     assertTrue(repoBase.resolve("root.json").toFile().exists());
     assertTrue(repoBase.resolve("targets").toFile().isDirectory());
   }
 
   @Test
-  void setTrustedRoot_backupPerformed(@TempDir Path repoBase) throws IOException {
-    TestResources.setupRepoFiles(PROD_REPO, repoBase, "root.json");
-    FileSystemTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
-    int version = tufStore.readMeta(RootRole.ROOT, Root.class).get().getSignedMeta().getVersion();
-    assertFalse(repoBase.resolve(version + ".root.json").toFile().exists());
-    tufStore.writeRoot(TestResources.loadRoot(TestResources.UPDATER_REAL_TRUSTED_ROOT));
-    assertTrue(repoBase.resolve(version + ".root.json").toFile().exists());
-  }
-
-  @Test
-  void clearMetaDueToKeyRotation(@TempDir Path repoBase) throws IOException {
+  void clearMeta(@TempDir Path repoBase) throws IOException {
     TestResources.setupRepoFiles(PROD_REPO, repoBase, "snapshot.json", "timestamp.json");
     FileSystemTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertTrue(repoBase.resolve("snapshot.json").toFile().exists());
     assertTrue(repoBase.resolve("timestamp.json").toFile().exists());
-    tufStore.clearMetaDueToKeyRotation();
-    assertFalse(repoBase.resolve("snapshot.json").toFile().exists());
+    tufStore.clearMeta(RootRole.TIMESTAMP);
+    assertTrue(repoBase.resolve("snapshot.json").toFile().exists());
     assertFalse(repoBase.resolve("timestamp.json").toFile().exists());
   }
 }


### PR DESCRIPTION
- don't persist N.root.json, could clash with a delegation
- validate at parsetime the type of meta file
- generify metastore a bit more, force updater to clear the right meta
- validate any bootstrapped root at update start time
- ~~perform an update on meta if download target is called directly and we haven't updated yet~~

more issues found during conformance, maybe I should just merge the conformance test suite in and fix these as I go from now on.