### PR TITLE
Handle targets with path elements

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -21,6 +21,8 @@ import com.google.common.annotations.VisibleForTesting;
 import dev.sigstore.tuf.model.*;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -65,12 +67,14 @@ public class FileSystemTufStore implements MetaStore, TargetStore {
 
   @Override
   public void writeTarget(String targetName, byte[] targetContents) throws IOException {
-    Files.write(targetsCache.resolve(targetName), targetContents);
+    var encoded = URLEncoder.encode(targetName, StandardCharsets.UTF_8);
+    Files.write(targetsCache.resolve(encoded), targetContents);
   }
 
   @Override
   public byte[] readTarget(String targetName) throws IOException {
-    return Files.readAllBytes(targetsCache.resolve(targetName));
+    var encoded = URLEncoder.encode(targetName, StandardCharsets.UTF_8);
+    return Files.readAllBytes(targetsCache.resolve(encoded));
   }
 
   @Override

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TargetReader.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TargetReader.java
@@ -21,7 +21,8 @@ import java.io.IOException;
 public interface TargetReader {
 
   /**
-   * Reads a TUF target file from the local TUF store
+   * Reads a TUF target file from the local TUF store. Target names may include path elements and
+   * the storage engine should be consistent when handling writing and reading these.
    *
    * @param targetName the name of the target file to read (e.g. ctfe.pub)
    * @return the content of the file as bytes

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TargetStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TargetStore.java
@@ -28,7 +28,8 @@ public interface TargetStore extends TargetReader {
   String getIdentifier();
 
   /**
-   * Writes a TUF target to the local target store.
+   * Writes a TUF target to the local target store. Target names may include path elements and the
+   * storage engine should be consistent when handling writing and reading these.
    *
    * @param targetName the name of the target file to write (e.g. ctfe.pub)
    * @param targetContents the content of the target file as bytes

--- a/tuf-cli/tuf-cli.xfails
+++ b/tuf-cli/tuf-cli.xfails
@@ -1,5 +1,4 @@
 test_metadata_bytes_match
-test_client_downloads_expected_file_in_sub_dir
 test_duplicate_sig_keyids
 test_unusual_role_name[?]
 test_unusual_role_name[#]


### PR DESCRIPTION
filesystem store stores them down as urlencoded, this mirrors behavior of the go-tuf client

