### PR TITLE
Make token string oidc client available outside of cli

### DIFF
--- a/sigstore-cli/src/main/java/dev/sigstore/cli/Sign.java
+++ b/sigstore-cli/src/main/java/dev/sigstore/cli/Sign.java
@@ -18,6 +18,7 @@ package dev.sigstore.cli;
 import dev.sigstore.KeylessSigner;
 import dev.sigstore.TrustedRootProvider;
 import dev.sigstore.oidc.client.OidcClients;
+import dev.sigstore.oidc.client.TokenStringOidcClient;
 import dev.sigstore.tuf.RootProvider;
 import dev.sigstore.tuf.SigstoreTufClient;
 import java.net.URL;
@@ -110,7 +111,7 @@ public class Sign implements Callable<Integer> {
     if (identityToken != null) {
       // If we've explicitly provided an identity token, customize the signer to only use the token
       // string OIDC client.
-      signerBuilder.oidcClients(OidcClients.of(new TokenStringOidcClient(identityToken)));
+      signerBuilder.oidcClients(OidcClients.of(TokenStringOidcClient.from(identityToken)));
     }
     var signer = signerBuilder.build();
     var bundle = signer.signFile(artifact);


### PR DESCRIPTION
@vlsi this is step towards making examples work of fork PRs. Once this is in, we need to add an equivalent gradle oidc thing and then inject the token from [conformance](https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/blob/current-token/oidc-token.txt) into it. wdyt?