### PR TITLE
tuf: use cached targets when available

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.spotless-base.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.spotless-base.gradle.kts
@@ -11,7 +11,7 @@ spotless {
         target("*.md", ".gitignore", "**/*.yaml")
 
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
     }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -78,6 +78,12 @@ public class FileSystemTufStore implements MetaStore, TargetStore {
   }
 
   @Override
+  public boolean hasTarget(String targetName) throws IOException {
+    var encoded = URLEncoder.encode(targetName, StandardCharsets.UTF_8);
+    return Files.isRegularFile(targetsDir.resolve(encoded));
+  }
+
+  @Override
   public void writeMeta(String roleName, SignedTufMeta<?> meta) throws IOException {
     storeRole(roleName, meta);
   }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TargetReader.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TargetReader.java
@@ -29,4 +29,13 @@ public interface TargetReader {
    * @throws IOException if an error occurs
    */
   byte[] readTarget(String targetName) throws IOException;
+
+  /**
+   * Checks if the local TUF store actually contains a target file with name.
+   *
+   * @param targetName the name of the target file to read (e.g. ctfe.pub)
+   * @return true if the target exists locally
+   * @throws IOException if an error occurs
+   */
+  boolean hasTarget(String targetName) throws IOException;
 }


### PR DESCRIPTION
Updates to latest tuf conformance which expects clients to make use of cached targets.