### PR TITLE
chore: do not require Java 17 for launching Gradle yet

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,5 @@
 rootProject.name = "sigstore-java-root"
 
-if (JavaVersion.current() < JavaVersion.VERSION_17) {
-    throw UnsupportedOperationException("Please use Java 17 or 21 for launching Gradle when building sigstore-java, the current Java is ${JavaVersion.current().majorVersion}")
-}
-
 includeBuild("build-logic-commons")
 includeBuild("build-logic")
 


### PR DESCRIPTION
#### Summary

We still require Java 17 for javac, however we could be fine if user launches Gradle with Java 8 or Java 11.

So far no plugins seems to require Java 17, so let's ease the requirements.

It should resolve issues with CodeQL autobuild which assumes we need Java 11: https://github.com/sigstore/sigstore-java/actions/runs/13782007549/job/38541785670#step:5:43

An alternative option would be going with manual build, however, I don't have time to investigate it.

#### Release Note

NONE

#### Documentation

NONE