### PR TITLE
Update google-java-format to 1.24.0

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
@@ -25,7 +25,7 @@ tasks.configureEach<JavaExec> {
 
 spotless {
     java {
-        googleJavaFormat("1.15.0")
+        googleJavaFormat("1.24.0")
         licenseHeaderFile("$rootDir/config/licenseHeader")
         // Note if submodule needs to add more exclusions, it should list ALL of them since
         // Spotless does not have "addTargetExclude" method

--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -93,12 +93,12 @@ spotless {
         )
     }
     format("conscrypt", com.diffplug.gradle.spotless.JavaExtension::class.java) {
-        googleJavaFormat("1.15.0")
+        googleJavaFormat("1.24.0")
         licenseHeaderFile("$rootDir/config/conscryptLicenseHeader")
         target("src/*/java/dev/sigstore/encryption/certificates/transparency/*.java")
     }
     format("webPki", com.diffplug.gradle.spotless.JavaExtension::class.java) {
-        googleJavaFormat("1.15.0")
+        googleJavaFormat("1.24.0")
         licenseHeaderFile("$rootDir/config/webPKILicenseHeader")
         target("src/*/java/dev/sigstore/json/canonicalizer/*.java")
     }

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -213,8 +213,12 @@ public class KeylessSigner implements AutoCloseable {
 
     @CheckReturnValue
     public KeylessSigner build()
-        throws CertificateException, IOException, NoSuchAlgorithmException, InvalidKeySpecException,
-            InvalidKeyException, InvalidAlgorithmParameterException {
+        throws CertificateException,
+            IOException,
+            NoSuchAlgorithmException,
+            InvalidKeySpecException,
+            InvalidKeyException,
+            InvalidAlgorithmParameterException {
       Preconditions.checkNotNull(trustedRootProvider);
       var trustedRoot = trustedRootProvider.get();
       Preconditions.checkNotNull(fulcioUri);
@@ -361,9 +365,16 @@ public class KeylessSigner implements AutoCloseable {
   }
 
   private void renewSigningCertificate()
-      throws InterruptedException, CertificateException, IOException, UnsupportedAlgorithmException,
-          NoSuchAlgorithmException, InvalidKeyException, SignatureException,
-          FulcioVerificationException, OidcException, KeylessSignerException {
+      throws InterruptedException,
+          CertificateException,
+          IOException,
+          UnsupportedAlgorithmException,
+          NoSuchAlgorithmException,
+          InvalidKeyException,
+          SignatureException,
+          FulcioVerificationException,
+          OidcException,
+          KeylessSignerException {
     // Check if the certificate is still valid
     lock.readLock().lock();
     try {

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
@@ -79,8 +79,12 @@ public class KeylessVerifier {
     private TrustedRootProvider trustedRootProvider;
 
     public KeylessVerifier build()
-        throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
-            NoSuchAlgorithmException, IOException, InvalidKeyException {
+        throws InvalidAlgorithmParameterException,
+            CertificateException,
+            InvalidKeySpecException,
+            NoSuchAlgorithmException,
+            IOException,
+            InvalidKeyException {
       Preconditions.checkNotNull(trustedRootProvider);
       var trustedRoot = trustedRootProvider.get();
       var fulcioVerifier = FulcioVerifier.newFulcioVerifier(trustedRoot);

--- a/sigstore-java/src/main/java/dev/sigstore/TrustedRootProvider.java
+++ b/sigstore-java/src/main/java/dev/sigstore/TrustedRootProvider.java
@@ -34,8 +34,12 @@ import java.security.spec.InvalidKeySpecException;
 public interface TrustedRootProvider {
 
   SigstoreTrustedRoot get()
-      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
-          NoSuchAlgorithmException, IOException, InvalidKeyException;
+      throws InvalidAlgorithmParameterException,
+          CertificateException,
+          InvalidKeySpecException,
+          NoSuchAlgorithmException,
+          IOException,
+          InvalidKeyException;
 
   static TrustedRootProvider from(SigstoreTufClient.Builder tufClientBuilder) {
     Preconditions.checkNotNull(tufClientBuilder);

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioVerifier.java
@@ -51,14 +51,18 @@ public class FulcioVerifier {
   private final CTVerifier ctVerifier;
 
   public static FulcioVerifier newFulcioVerifier(SigstoreTrustedRoot trustRoot)
-      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
+      throws InvalidAlgorithmParameterException,
+          CertificateException,
+          InvalidKeySpecException,
           NoSuchAlgorithmException {
     return newFulcioVerifier(trustRoot.getCAs(), trustRoot.getCTLogs());
   }
 
   public static FulcioVerifier newFulcioVerifier(
       List<CertificateAuthority> cas, List<TransparencyLog> ctLogs)
-      throws InvalidKeySpecException, NoSuchAlgorithmException, InvalidAlgorithmParameterException,
+      throws InvalidKeySpecException,
+          NoSuchAlgorithmException,
+          InvalidAlgorithmParameterException,
           CertificateException {
     List<CTLogInfo> logs = new ArrayList<>();
     for (var ctLog : ctLogs) {

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntryFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntryFetcher.java
@@ -45,28 +45,44 @@ public class RekorEntryFetcher {
   private final List<RekorClient> rekorClients;
 
   public static RekorEntryFetcher sigstoreStaging()
-      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
-          NoSuchAlgorithmException, IOException, InvalidKeyException {
+      throws InvalidAlgorithmParameterException,
+          CertificateException,
+          InvalidKeySpecException,
+          NoSuchAlgorithmException,
+          IOException,
+          InvalidKeyException {
     var sigstoreTufClientBuilder = SigstoreTufClient.builder().useStagingInstance();
     return fromTrustedRoot(TrustedRootProvider.from(sigstoreTufClientBuilder));
   }
 
   public static RekorEntryFetcher sigstorePublicGood()
-      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
-          NoSuchAlgorithmException, IOException, InvalidKeyException {
+      throws InvalidAlgorithmParameterException,
+          CertificateException,
+          InvalidKeySpecException,
+          NoSuchAlgorithmException,
+          IOException,
+          InvalidKeyException {
     var sigstoreTufClientBuilder = SigstoreTufClient.builder().usePublicGoodInstance();
     return fromTrustedRoot(TrustedRootProvider.from(sigstoreTufClientBuilder));
   }
 
   public static RekorEntryFetcher fromTrustedRoot(Path trustedRoot)
-      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
-          NoSuchAlgorithmException, IOException, InvalidKeyException {
+      throws InvalidAlgorithmParameterException,
+          CertificateException,
+          InvalidKeySpecException,
+          NoSuchAlgorithmException,
+          IOException,
+          InvalidKeyException {
     return fromTrustedRoot(TrustedRootProvider.from(trustedRoot));
   }
 
   public static RekorEntryFetcher fromTrustedRoot(TrustedRootProvider trustedRootProvider)
-      throws InvalidAlgorithmParameterException, CertificateException, InvalidKeySpecException,
-          NoSuchAlgorithmException, IOException, InvalidKeyException {
+      throws InvalidAlgorithmParameterException,
+          CertificateException,
+          InvalidKeySpecException,
+          NoSuchAlgorithmException,
+          IOException,
+          InvalidKeyException {
     var trustedRoot = trustedRootProvider.get();
     var rekorClients =
         trustedRoot.getTLogs().stream()

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -152,7 +152,10 @@ public class SigstoreTufClient {
    * defined on the client.
    */
   public void update()
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException,
+      throws IOException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException,
+          InvalidKeyException,
           CertificateException {
     if (lastUpdate == null
         || Duration.between(lastUpdate, Instant.now()).compareTo(cacheValidity) > 0) {
@@ -162,7 +165,10 @@ public class SigstoreTufClient {
 
   /** Force an update, ignoring any cache validity. */
   public void forceUpdate()
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException,
+      throws IOException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException,
+          InvalidKeyException,
           CertificateException {
     updater.update();
     lastUpdate = Instant.now();

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/Updater.java
@@ -142,8 +142,13 @@ public class Updater {
 
   // https://theupdateframework.github.io/specification/latest/#detailed-client-workflow
   void updateRoot()
-      throws IOException, RoleExpiredException, NoSuchAlgorithmException, InvalidKeySpecException,
-          FileExceedsMaxLengthException, RollbackVersionException, SignatureVerificationException {
+      throws IOException,
+          RoleExpiredException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException,
+          FileExceedsMaxLengthException,
+          RollbackVersionException,
+          SignatureVerificationException {
     // 5.3.1) record the time at start and use for expiration checks consistently throughout the
     // update.
     updateStartTime = ZonedDateTime.now(clock);
@@ -319,7 +324,10 @@ public class Updater {
   }
 
   void updateTimestamp()
-      throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, FileNotFoundException,
+      throws IOException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException,
+          FileNotFoundException,
           SignatureVerificationException {
     // 1) download the timestamp.json bytes.
     var timestamp =
@@ -352,8 +360,12 @@ public class Updater {
   }
 
   void updateSnapshot()
-      throws IOException, FileNotFoundException, InvalidHashesException,
-          SignatureVerificationException, NoSuchAlgorithmException, InvalidKeySpecException {
+      throws IOException,
+          FileNotFoundException,
+          InvalidHashesException,
+          SignatureVerificationException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException {
     // 1) download the snapshot.json bytes up to timestamp's snapshot length.
     int timestampSnapshotVersion =
         trustedMetaStore.getTimestamp().getSignedMeta().getSnapshotMeta().getVersion();
@@ -441,8 +453,12 @@ public class Updater {
   }
 
   void updateTargets()
-      throws IOException, FileNotFoundException, InvalidHashesException,
-          SignatureVerificationException, NoSuchAlgorithmException, InvalidKeySpecException,
+      throws IOException,
+          FileNotFoundException,
+          InvalidHashesException,
+          SignatureVerificationException,
+          NoSuchAlgorithmException,
+          InvalidKeySpecException,
           FileExceedsMaxLengthException {
     // 1) download the targets.json up to targets.json length in bytes.
     SnapshotMeta.SnapshotTarget targetMeta =

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientHttpTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientHttpTest.java
@@ -160,8 +160,12 @@ public class RekorClientHttpTest {
 
   @NotNull
   private static HashedRekordRequest createdRekorRequest()
-      throws NoSuchAlgorithmException, InvalidKeyException, SignatureException,
-          OperatorCreationException, CertificateException, IOException {
+      throws NoSuchAlgorithmException,
+          InvalidKeyException,
+          SignatureException,
+          OperatorCreationException,
+          CertificateException,
+          IOException {
     // the data we want to sign
     var data = "some data " + UUID.randomUUID();
 

--- a/sigstore-java/src/test/java/dev/sigstore/testing/CertGenerator.java
+++ b/sigstore-java/src/test/java/dev/sigstore/testing/CertGenerator.java
@@ -49,7 +49,9 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
  */
 public class CertGenerator {
   public static Certificate newCert(PublicKey publicKey)
-      throws OperatorCreationException, CertificateException, IOException,
+      throws OperatorCreationException,
+          CertificateException,
+          IOException,
           NoSuchAlgorithmException {
 
     // generate a keypair for signing this certificate


### PR DESCRIPTION
1.25.0+ require a minimum java build version of 17, so we can update to latest as we upgrade our build.
