### PR TITLE
Allow targetStore to return input streams

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/TrustedRootProvider.java
+++ b/sigstore-java/src/main/java/dev/sigstore/TrustedRootProvider.java
@@ -16,12 +16,9 @@
 package dev.sigstore;
 
 import com.google.common.base.Preconditions;
-import com.google.protobuf.util.JsonFormat;
-import dev.sigstore.proto.trustroot.v1.TrustedRoot;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
 import dev.sigstore.tuf.SigstoreTufClient;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.InvalidAlgorithmParameterException;
@@ -53,10 +50,9 @@ public interface TrustedRootProvider {
   static TrustedRootProvider from(Path trustedRoot) {
     Preconditions.checkNotNull(trustedRoot);
     return () -> {
-      var trustedRootBuilder = TrustedRoot.newBuilder();
-      JsonFormat.parser()
-          .merge(Files.readString(trustedRoot, StandardCharsets.UTF_8), trustedRootBuilder);
-      return SigstoreTrustedRoot.from(trustedRootBuilder.build());
+      try (var is = Files.newInputStream(trustedRoot)) {
+        return SigstoreTrustedRoot.from(is);
+      }
     };
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/SigstoreTrustedRoot.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/SigstoreTrustedRoot.java
@@ -16,7 +16,13 @@
 package dev.sigstore.trustroot;
 
 import com.google.api.client.util.Lists;
+import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import dev.sigstore.proto.trustroot.v1.TrustedRootOrBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,17 +31,26 @@ import org.immutables.value.Value.Immutable;
 @Immutable
 public interface SigstoreTrustedRoot {
 
-  /** A list of certificate authorities associated with this trustroot. */
+  /** A list of certificate authorities associated with this trustedroot. */
   List<CertificateAuthority> getCAs();
 
-  /** A list of binary transparency logs associated with this trustroot. */
+  /** A list of binary transparency logs associated with this trustedroot. */
   List<TransparencyLog> getTLogs();
 
-  /** A list of certificate transparency logs associated with this trustroot. */
+  /** A list of certificate transparency logs associated with this trustedroot. */
   List<TransparencyLog> getCTLogs();
 
-  /** Create an instance from a parsed proto definition of a trustroot. */
-  static SigstoreTrustedRoot from(TrustedRoot proto) throws CertificateException {
+  /** Create an instance from an input stream of a json representation of a trustedroot. */
+  static SigstoreTrustedRoot from(InputStream json) throws IOException, CertificateException {
+    var trustedRootBuilder = TrustedRoot.newBuilder();
+    try (var reader = new InputStreamReader(json, StandardCharsets.UTF_8)) {
+      JsonFormat.parser().merge(reader, trustedRootBuilder);
+    }
+    return from(trustedRootBuilder);
+  }
+
+  /** Create an instance from a parsed proto definition of a trustedroot. */
+  static SigstoreTrustedRoot from(TrustedRootOrBuilder proto) throws CertificateException {
     List<CertificateAuthority> cas = Lists.newArrayList();
     for (var certAuthority : proto.getCertificateAuthoritiesList()) {
       cas.add(CertificateAuthority.from(certAuthority));

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import dev.sigstore.tuf.model.*;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -75,6 +76,12 @@ public class FileSystemTufStore implements MetaStore, TargetStore {
   public byte[] readTarget(String targetName) throws IOException {
     var encoded = URLEncoder.encode(targetName, StandardCharsets.UTF_8);
     return Files.readAllBytes(targetsDir.resolve(encoded));
+  }
+
+  @Override
+  public InputStream getTargetInputSteam(String targetName) throws IOException {
+    var encoded = URLEncoder.encode(targetName, StandardCharsets.UTF_8);
+    return Files.newInputStream(targetsDir.resolve(encoded));
   }
 
   @Override

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TargetReader.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TargetReader.java
@@ -16,6 +16,7 @@
 package dev.sigstore.tuf;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /** Interface that defines reading targets from local storage. */
 public interface TargetReader {
@@ -29,6 +30,18 @@ public interface TargetReader {
    * @throws IOException if an error occurs
    */
   byte[] readTarget(String targetName) throws IOException;
+
+  /**
+   * Returns an input stream to a TUF target file in the local TUF store. Target names may include
+   * path elements and the storage engine should be consistent when handling writing and reading
+   * these.
+   *
+   * @param targetName the name of the target file to read (e.g. ctfe.pub)
+   * @return an input steam to the target file in the local store, the consumer must close the input
+   *     stream
+   * @throws IOException if an error occurs
+   */
+  InputStream getTargetInputSteam(String targetName) throws IOException;
 
   /**
    * Checks if the local TUF store actually contains a target file with name.

--- a/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioVerifierTest.java
@@ -16,10 +16,8 @@
 package dev.sigstore.fulcio.client;
 
 import com.google.common.io.Resources;
-import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.bundle.Bundle;
 import dev.sigstore.encryption.certificates.Certificates;
-import dev.sigstore.proto.trustroot.v1.TrustedRoot;
 import dev.sigstore.trustroot.ImmutableLogId;
 import dev.sigstore.trustroot.ImmutableTransparencyLog;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
@@ -59,14 +57,9 @@ public class FulcioVerifierTest {
 
   @BeforeAll
   public static void initTrustRoot() throws Exception {
-    var json =
-        Resources.toString(
-            Resources.getResource("dev/sigstore/trustroot/trusted_root.json"),
-            StandardCharsets.UTF_8);
-    var builder = TrustedRoot.newBuilder();
-    JsonFormat.parser().merge(json, builder);
-
-    trustRoot = SigstoreTrustedRoot.from(builder.build());
+    trustRoot =
+        SigstoreTrustedRoot.from(
+            Resources.getResource("dev/sigstore/trustroot/trusted_root.json").openStream());
   }
 
   @Test

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
@@ -16,8 +16,6 @@
 package dev.sigstore.rekor.client;
 
 import com.google.common.io.Resources;
-import com.google.protobuf.util.JsonFormat;
-import dev.sigstore.proto.trustroot.v1.TrustedRoot;
 import dev.sigstore.trustroot.ImmutableLogId;
 import dev.sigstore.trustroot.ImmutablePublicKey;
 import dev.sigstore.trustroot.ImmutableTransparencyLog;
@@ -58,14 +56,9 @@ public class RekorVerifierTest {
 
   @BeforeAll
   public static void initTrustRoot() throws IOException, CertificateException {
-    var json =
-        Resources.toString(
-            Resources.getResource("dev/sigstore/trustroot/staging_trusted_root.json"),
-            StandardCharsets.UTF_8);
-    var builder = TrustedRoot.newBuilder();
-    JsonFormat.parser().merge(json, builder);
-
-    trustRoot = SigstoreTrustedRoot.from(builder.build());
+    trustRoot =
+        SigstoreTrustedRoot.from(
+            Resources.getResource("dev/sigstore/trustroot/staging_trusted_root.json").openStream());
   }
 
   @Test

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
@@ -21,10 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.io.Resources;
-import com.google.protobuf.util.JsonFormat;
-import dev.sigstore.proto.trustroot.v1.TrustedRoot;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -38,14 +35,9 @@ class SigstoreTrustedRootTest {
 
   @BeforeAll
   public static void initTrustRoot() throws IOException, CertificateException {
-    var json =
-        Resources.toString(
-            Resources.getResource("dev/sigstore/trustroot/trusted_root.json"),
-            StandardCharsets.UTF_8);
-    var builder = TrustedRoot.newBuilder();
-    JsonFormat.parser().merge(json, builder);
-
-    trustRoot = SigstoreTrustedRoot.from(builder.build());
+    trustRoot =
+        SigstoreTrustedRoot.from(
+            Resources.getResource("dev/sigstore/trustroot/trusted_root.json").openStream());
   }
 
   @Test


### PR DESCRIPTION
Allows us to read targets as inputs streams and then pass those around instead of full files.