### PR TITLE
Use SigstoreConfigurationException more widely

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -46,6 +46,7 @@ import dev.sigstore.rekor.client.RekorParseException;
 import dev.sigstore.rekor.client.RekorResponse;
 import dev.sigstore.rekor.client.RekorVerificationException;
 import dev.sigstore.rekor.client.RekorVerifier;
+import dev.sigstore.trustroot.SigstoreConfigurationException;
 import dev.sigstore.tuf.SigstoreTufClient;
 import java.io.IOException;
 import java.net.URI;
@@ -218,7 +219,8 @@ public class KeylessSigner implements AutoCloseable {
             NoSuchAlgorithmException,
             InvalidKeySpecException,
             InvalidKeyException,
-            InvalidAlgorithmParameterException {
+            InvalidAlgorithmParameterException,
+            SigstoreConfigurationException {
       Preconditions.checkNotNull(trustedRootProvider);
       var trustedRoot = trustedRootProvider.get();
       Preconditions.checkNotNull(fulcioUri);

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
@@ -37,6 +37,7 @@ import dev.sigstore.rekor.client.RekorVerificationException;
 import dev.sigstore.rekor.client.RekorVerifier;
 import dev.sigstore.rekor.dsse.v0_0_1.Dsse;
 import dev.sigstore.rekor.dsse.v0_0_1.PayloadHash;
+import dev.sigstore.trustroot.SigstoreConfigurationException;
 import dev.sigstore.tuf.SigstoreTufClient;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -79,12 +80,11 @@ public class KeylessVerifier {
     private TrustedRootProvider trustedRootProvider;
 
     public KeylessVerifier build()
-        throws InvalidAlgorithmParameterException,
+        throws SigstoreConfigurationException,
+            InvalidAlgorithmParameterException,
             CertificateException,
             InvalidKeySpecException,
-            NoSuchAlgorithmException,
-            IOException,
-            InvalidKeyException {
+            NoSuchAlgorithmException {
       Preconditions.checkNotNull(trustedRootProvider);
       var trustedRoot = trustedRootProvider.get();
       var fulcioVerifier = FulcioVerifier.newFulcioVerifier(trustedRoot);

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntryFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntryFetcher.java
@@ -18,18 +18,14 @@ package dev.sigstore.rekor.client;
 import dev.sigstore.KeylessVerificationException;
 import dev.sigstore.TrustedRootProvider;
 import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.trustroot.SigstoreConfigurationException;
 import dev.sigstore.trustroot.TransparencyLog;
 import dev.sigstore.tuf.SigstoreTufClient;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import java.sql.Date;
 import java.util.List;
 import java.util.Optional;
@@ -44,45 +40,23 @@ public class RekorEntryFetcher {
   // a client per remote trusted log
   private final List<RekorClient> rekorClients;
 
-  public static RekorEntryFetcher sigstoreStaging()
-      throws InvalidAlgorithmParameterException,
-          CertificateException,
-          InvalidKeySpecException,
-          NoSuchAlgorithmException,
-          IOException,
-          InvalidKeyException {
+  public static RekorEntryFetcher sigstoreStaging() throws SigstoreConfigurationException {
     var sigstoreTufClientBuilder = SigstoreTufClient.builder().useStagingInstance();
     return fromTrustedRoot(TrustedRootProvider.from(sigstoreTufClientBuilder));
   }
 
-  public static RekorEntryFetcher sigstorePublicGood()
-      throws InvalidAlgorithmParameterException,
-          CertificateException,
-          InvalidKeySpecException,
-          NoSuchAlgorithmException,
-          IOException,
-          InvalidKeyException {
+  public static RekorEntryFetcher sigstorePublicGood() throws SigstoreConfigurationException {
     var sigstoreTufClientBuilder = SigstoreTufClient.builder().usePublicGoodInstance();
     return fromTrustedRoot(TrustedRootProvider.from(sigstoreTufClientBuilder));
   }
 
   public static RekorEntryFetcher fromTrustedRoot(Path trustedRoot)
-      throws InvalidAlgorithmParameterException,
-          CertificateException,
-          InvalidKeySpecException,
-          NoSuchAlgorithmException,
-          IOException,
-          InvalidKeyException {
+      throws SigstoreConfigurationException {
     return fromTrustedRoot(TrustedRootProvider.from(trustedRoot));
   }
 
   public static RekorEntryFetcher fromTrustedRoot(TrustedRootProvider trustedRootProvider)
-      throws InvalidAlgorithmParameterException,
-          CertificateException,
-          InvalidKeySpecException,
-          NoSuchAlgorithmException,
-          IOException,
-          InvalidKeyException {
+      throws SigstoreConfigurationException {
     var trustedRoot = trustedRootProvider.get();
     var rekorClients =
         trustedRoot.getTLogs().stream()

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.proto.trustroot.v1.TrustedRoot;
+import dev.sigstore.trustroot.SigstoreConfigurationException;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -28,7 +29,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.time.Instant;
@@ -152,11 +152,11 @@ public class SigstoreTufClient {
    * defined on the client.
    */
   public void update()
-      throws IOException,
+      throws SigstoreConfigurationException,
+          IOException,
           NoSuchAlgorithmException,
           InvalidKeySpecException,
-          InvalidKeyException,
-          CertificateException {
+          InvalidKeyException {
     if (lastUpdate == null
         || Duration.between(lastUpdate, Instant.now()).compareTo(cacheValidity) > 0) {
       this.forceUpdate();
@@ -165,11 +165,11 @@ public class SigstoreTufClient {
 
   /** Force an update, ignoring any cache validity. */
   public void forceUpdate()
-      throws IOException,
+      throws SigstoreConfigurationException,
+          IOException,
           NoSuchAlgorithmException,
           InvalidKeySpecException,
-          InvalidKeyException,
-          CertificateException {
+          InvalidKeyException {
     updater.update();
     lastUpdate = Instant.now();
     var trustedRootBuilder = TrustedRoot.newBuilder();

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
@@ -24,7 +24,6 @@ import dev.sigstore.trustroot.SigstoreTrustedRoot;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.security.cert.CertificateException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -55,7 +54,7 @@ public class RekorVerifierTest {
   }
 
   @BeforeAll
-  public static void initTrustRoot() throws IOException, CertificateException {
+  public static void initTrustRoot() throws Exception {
     trustRoot =
         SigstoreTrustedRoot.from(
             Resources.getResource("dev/sigstore/trustroot/staging_trusted_root.json").openStream());

--- a/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/trustroot/SigstoreTrustedRootTest.java
@@ -21,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.io.Resources;
-import java.io.IOException;
-import java.security.cert.CertificateException;
 import java.time.ZonedDateTime;
 import java.util.List;
 import org.bouncycastle.util.encoders.Base64;
@@ -34,7 +32,7 @@ class SigstoreTrustedRootTest {
   private static SigstoreTrustedRoot trustRoot;
 
   @BeforeAll
-  public static void initTrustRoot() throws IOException, CertificateException {
+  public static void initTrustRoot() throws Exception {
     trustRoot =
         SigstoreTrustedRoot.from(
             Resources.getResource("dev/sigstore/trustroot/trusted_root.json").openStream());


### PR DESCRIPTION
This is kind of a low priority part of #954 but still uses SigstoreConfigurationException rather than revealing a whole bunch of internal workings directly.