### PR TITLE
chore: migrate to Kotlin Dokka 2.0

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.90")
     implementation("de.thetaphi.forbiddenapis:de.thetaphi.forbiddenapis.gradle.plugin:3.9")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    implementation("org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:2.0.0")
+    implementation("org.jetbrains.dokka-javadoc:org.jetbrains.dokka-javadoc.gradle.plugin:2.0.0")
     implementation("com.github.autostyle:com.github.autostyle.gradle.plugin:4.0")
     implementation("net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:4.2.0")
 }

--- a/build-logic/jvm/src/main/kotlin/build-logic.dokka-javadoc.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.dokka-javadoc.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-base")
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
     id("build-logic.build-params")
 }
 
@@ -14,7 +14,7 @@ java {
 val dokkaJar by tasks.registering(Jar::class) {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Assembles a jar archive containing javadoc"
-    from(tasks.dokkaJavadoc)
+    from(tasks.dokkaGeneratePublicationJavadoc)
     archiveClassifier.set("javadoc")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,7 @@ group=dev.sigstore
 
 # use the ./scripts/update_version.sh script to update all versions
 version=1.4.0
+
+# Kotlin Dokka is experemental, and we want silence the build warning
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true


### PR DESCRIPTION
#### Summary

Dokka 2 is still experimental, however, we use very basic apis, so let's migrate and silence the warning.

#### Release Note
NONE

#### Documentation
NONE