### PR TITLE
Add RFC3161 timestamps to keyless signer and verifier

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/timestamp/client/TimestampClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/timestamp/client/TimestampClient.java
@@ -15,8 +15,12 @@
  */
 package dev.sigstore.timestamp.client;
 
+import java.net.URI;
+
 /** A client to communicate with a timestamp service instance. */
 public interface TimestampClient {
+  URI STAGING_URI = URI.create("https://timestamp.sigstage.dev/api/v1/timestamp");
+
   /**
    * Request a timestanp for a timestamp authority.
    *

--- a/sigstore-java/src/main/java/dev/sigstore/timestamp/client/TimestampClientHttp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/timestamp/client/TimestampClientHttp.java
@@ -34,8 +34,6 @@ import org.bouncycastle.tsp.TimeStampResponse;
 
 /** A client to communicate with a timestamp service instance. */
 public class TimestampClientHttp implements TimestampClient {
-  private static final URI SIGSTORE_TSA_URI =
-      URI.create("https://timestamp.sigstage.dev/api/v1/timestamp");
   private static final String CONTENT_TYPE_TIMESTAMP_QUERY = "application/timestamp-query";
   private static final String ACCEPT_TYPE_TIMESTAMP_REPLY = "application/timestamp-reply";
 
@@ -54,7 +52,7 @@ public class TimestampClientHttp implements TimestampClient {
 
   public static class Builder {
     private HttpParams httpParams = ImmutableHttpParams.builder().build();
-    private URI uri = SIGSTORE_TSA_URI;
+    private URI uri = TimestampClient.STAGING_URI;
 
     private Builder() {}
 

--- a/sigstore-java/src/main/java/dev/sigstore/timestamp/client/TimestampResponse.java
+++ b/sigstore-java/src/main/java/dev/sigstore/timestamp/client/TimestampResponse.java
@@ -15,10 +15,25 @@
  */
 package dev.sigstore.timestamp.client;
 
+import java.io.IOException;
+import java.util.Date;
+import org.bouncycastle.tsp.TSPException;
+import org.bouncycastle.tsp.TimeStampResponse;
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Lazy;
 
 @Immutable
 public interface TimestampResponse {
   /** The ASN.1 encoded representation of the timestamp response. */
   byte[] getEncoded();
+
+  @Lazy
+  default Date getGenTime() throws TimestampException {
+    try {
+      var bcTsResp = new TimeStampResponse(getEncoded());
+      return bcTsResp.getTimeStampToken().getTimeStampInfo().getGenTime();
+    } catch (TSPException | IOException e) {
+      throw new TimestampException("Failed to retrieve timestamp generation time", e);
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #959 and thus closes #699

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change allows for the `KeylessSigner` to add RFC3161 timestamps to a bundle and `KeylessVerifier` to verify such timestamps.