### PR TITLE
Update protobuf-specs

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation("io.github.erdtman:java-json-canonicalization:1.1")
 
     // this requires inclusion of protos is src/main/proto
-    protobuf("dev.sigstore:protobuf-specs:0.4.1")
+    protobuf("dev.sigstore:protobuf-specs:0.4.3")
 
     implementation(platform("com.google.protobuf:protobuf-bom:4.30.2"))
     implementation("com.google.protobuf:protobuf-java-util")

--- a/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLog.java
+++ b/sigstore-java/src/main/java/dev/sigstore/trustroot/TransparencyLog.java
@@ -34,6 +34,8 @@ public interface TransparencyLog {
 
   PublicKey getPublicKey();
 
+  // TODO (https://github.com/sigstore/sigstore-java/issues/987) move off of log_id
+  @SuppressWarnings("deprecation")
   static TransparencyLog from(TransparencyLogInstance proto) {
     return ImmutableTransparencyLog.builder()
         .baseUrl(URI.create(proto.getBaseUrl()))


### PR DESCRIPTION
- we'll handle the log_id deprecation later
- this includes all rekor_v2 types (but not service defs)