### PR TITLE
Extract inclusion proof verifier into a new library

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/merkle/InclusionProofVerificationException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/merkle/InclusionProofVerificationException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.merkle;
+
+public class InclusionProofVerificationException extends Exception {
+  public InclusionProofVerificationException(String message) {
+    super(message);
+  }
+
+  public InclusionProofVerificationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public InclusionProofVerificationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/merkle/InclusionProofVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/merkle/InclusionProofVerifier.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.merkle;
+
+import com.google.common.hash.Hashing;
+import java.util.Arrays;
+import java.util.List;
+import org.bouncycastle.util.encoders.Hex;
+
+/** Verifier for inclusion proofs. */
+public class InclusionProofVerifier {
+  /**
+   * Verifies an inclusion proof.
+   *
+   * @param leafHash the hash of the leaf entry.
+   * @param logIndex the index of the leaf in the log.
+   * @param treeSize the size of the tree at the time the proof was generated.
+   * @param proofHashes a list of hashes from the inclusion proof.
+   * @param expectedRootHash the expected root hash of the Merkle tree.
+   * @throws InclusionProofVerificationException if the proof is invalid.
+   */
+  public static void verify(
+      byte[] leafHash,
+      long logIndex,
+      long treeSize,
+      List<byte[]> proofHashes,
+      byte[] expectedRootHash)
+      throws InclusionProofVerificationException {
+    byte[] currentHash = leafHash;
+    long nodeIndex = logIndex;
+    long totalNodes = treeSize - 1;
+
+    for (byte[] hash : proofHashes) {
+      if (totalNodes == 0) {
+        throw new InclusionProofVerificationException("Inclusion proof failed, ended prematurely");
+      }
+      if (nodeIndex == totalNodes || nodeIndex % 2 == 1) {
+        currentHash = hashChildren(hash, currentHash);
+        while (nodeIndex % 2 == 0) {
+          nodeIndex = nodeIndex >> 1;
+          totalNodes = totalNodes >> 1;
+        }
+      } else {
+        currentHash = hashChildren(currentHash, hash);
+      }
+      nodeIndex = nodeIndex >> 1;
+      totalNodes = totalNodes >> 1;
+    }
+
+    if (!Arrays.equals(currentHash, expectedRootHash)) {
+      throw new InclusionProofVerificationException(
+          "Calculated inclusion proof root hash does not match provided root hash\n"
+              + "calculated: "
+              + Hex.toHexString(currentHash)
+              + "\n"
+              + "provided:   "
+              + Hex.toHexString(expectedRootHash));
+    }
+  }
+
+  /**
+   * Hashes the concatenation of a 0x01 byte, the left child hash, and the right child hash using
+   * SHA-256.
+   *
+   * @param left the left child hash.
+   * @param right the right child hash.
+   * @return the parent hash.
+   */
+  public static byte[] hashChildren(byte[] left, byte[] right) {
+    return Hashing.sha256()
+        .newHasher()
+        .putByte((byte) 0x01)
+        .putBytes(left)
+        .putBytes(right)
+        .hash()
+        .asBytes();
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorVerifier.java
@@ -17,6 +17,8 @@ package dev.sigstore.rekor.client;
 
 import com.google.common.hash.Hashing;
 import dev.sigstore.encryption.signers.Verifiers;
+import dev.sigstore.merkle.InclusionProofVerificationException;
+import dev.sigstore.merkle.InclusionProofVerifier;
 import dev.sigstore.rekor.client.RekorEntry.Checkpoint;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
 import dev.sigstore.trustroot.TransparencyLog;
@@ -25,6 +27,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -92,49 +95,32 @@ public class RekorVerifier {
 
   /** Verify that a Rekor Entry is in the log by checking inclusion proof. */
   private void verifyInclusionProof(RekorEntry entry) throws RekorVerificationException {
-
     var inclusionProof = entry.getVerification().getInclusionProof();
 
     var leafHash =
         Hashing.sha256()
-            .hashBytes(combineBytes(new byte[] {0x00}, Base64.getDecoder().decode(entry.getBody())))
+            .newHasher()
+            .putByte((byte) 0x00)
+            .putBytes(Base64.getDecoder().decode(entry.getBody()))
+            .hash()
             .asBytes();
 
-    // see: https://datatracker.ietf.org/doc/rfc9162/ section 2.1.3.2
-
-    // nodeIndex and totalNodes represent values for a specific level in the tree
-    // starting at the leafs and moving up to the root.
-    var nodeIndex = inclusionProof.getLogIndex();
-    var totalNodes = inclusionProof.getTreeSize() - 1;
-
-    var currentHash = leafHash;
-    var hashes = inclusionProof.getHashes();
-
-    for (var hash : hashes) {
-      byte[] p = Hex.decode(hash);
-      if (totalNodes == 0) {
-        throw new RekorVerificationException("Inclusion proof failed, ended prematurely");
-      }
-      if (nodeIndex == totalNodes || nodeIndex % 2 == 1) {
-        currentHash = hashChildren(p, currentHash);
-        while (nodeIndex % 2 == 0) {
-          nodeIndex = nodeIndex >> 1;
-          totalNodes = totalNodes >> 1;
-        }
-      } else {
-        currentHash = hashChildren(currentHash, p);
-      }
-      nodeIndex = nodeIndex >> 1;
-      totalNodes = totalNodes >> 1;
+    List<byte[]> hashes = new ArrayList<>();
+    for (String hash : inclusionProof.getHashes()) {
+      hashes.add(Hex.decode(hash));
     }
 
-    var calcuatedRootHash = Hex.toHexString(currentHash);
-    if (!calcuatedRootHash.equals(inclusionProof.getRootHash())) {
-      throw new RekorVerificationException(
-          "Calculated inclusion proof root hash does not match provided root hash\n"
-              + calcuatedRootHash
-              + "\n"
-              + inclusionProof.getRootHash());
+    byte[] expectedRootHash = Hex.decode(inclusionProof.getRootHash());
+
+    try {
+      InclusionProofVerifier.verify(
+          leafHash,
+          inclusionProof.getLogIndex(),
+          inclusionProof.getTreeSize(),
+          hashes,
+          expectedRootHash);
+    } catch (InclusionProofVerificationException e) {
+      throw new RekorVerificationException("Inclusion proof verification failed", e);
     }
   }
 
@@ -176,19 +162,5 @@ public class RekorVerifier {
         | InvalidKeyException ex) {
       throw new RekorVerificationException("Could not verify checkpoint signature", ex);
     }
-  }
-
-  private static byte[] combineBytes(byte[] first, byte[] second) {
-    byte[] result = new byte[first.length + second.length];
-    System.arraycopy(first, 0, result, 0, first.length);
-    System.arraycopy(second, 0, result, first.length, second.length);
-    return result;
-  }
-
-  // hash the concatination of 0x01, left and right
-  private static byte[] hashChildren(byte[] left, byte[] right) {
-    return Hashing.sha256()
-        .hashBytes(combineBytes(new byte[] {0x01}, combineBytes(left, right)))
-        .asBytes();
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/merkle/InclusionProofVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/merkle/InclusionProofVerifierTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.merkle;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class InclusionProofVerifierTest {
+  public static byte[] leafHash;
+  public static long logIndex;
+  public static long treeSize;
+  public static List<byte[]> proofHashes;
+  public static byte[] expectedRootHash;
+
+  @BeforeAll
+  public static void initValues() throws Exception {
+    // Test values taken from the inclusion proof in
+    // src/test/resources/dev/sigstore/samples/rekor-response/valid/entry.json
+    leafHash = Hex.decode("ac3650aee1c1b3821211cf07067c1a118d0a7f86867bbb1df340cb8fc9c221af");
+    logIndex = 1227L;
+    treeSize = 14358L;
+    proofHashes =
+        List.of(
+            Hex.decode("810320ec3029914695826d60133c67021f66ee0cfb09a6f79eb267ed9f55de2c"),
+            Hex.decode("67e9d9f66f0ad388f7e1a20991e9a2ae3efad5cbf281e8b3d2aaf1ef99a4618c"),
+            Hex.decode("16a106400c53465f6e18c2475df6ba889ca30f5667bacf32b1a5661f14a5080c"),
+            Hex.decode("b4439e8d71edbc96271723cb7a969dd725e23e73d139361864a62ed76ce8dc11"),
+            Hex.decode("49b3e90806c7b63b5a86f5748e3ecb7d264ea0828eb74a45bc1a2cd7962408e8"),
+            Hex.decode("5059ad9b48fa50bd9adcbff0dd81c5a0dcb60f37e0716e723a33805a464f72f8"),
+            Hex.decode("6c2ce64219799e61d72996884eee9e19fb906e4d7fa04b71625fde4108f21762"),
+            Hex.decode("784f79c817abb78db3ae99b6c1ede640470bf4bb678673a05bf3a6b50aaaddd6"),
+            Hex.decode("c6d92ebf4e10cdba500ca410166cd0a8d8b312154d2f45bc4292d63dea6112f6"),
+            Hex.decode("1768732027401f6718b0df7769e2803127cfc099eb130a8ed7d913218f6a65f6"),
+            Hex.decode("0da021f68571b65e49e926e4c69024de3ac248a1319d254bc51a85a657b93c33"),
+            Hex.decode("bc8cf0c8497d5c24841de0c9bef598ec99bbd59d9538d58568340646fe289e9a"),
+            Hex.decode("be328fa737b8fa9461850b8034250f237ff5b0b590b9468e6223968df294872b"),
+            Hex.decode("6f06f4025d0346f04830352b23f65c8cd9e3ce4b8cb899877c35282521ddaf85"));
+    expectedRootHash =
+        Hex.decode("effa4fa4575f72829016a64e584441203de533212f9470d63a56d1992e73465d");
+  }
+
+  @Test
+  public void verify() throws Exception {
+    InclusionProofVerifier.verify(leafHash, logIndex, treeSize, proofHashes, expectedRootHash);
+  }
+
+  @Test
+  public void verify_endPrematurely() throws Exception {
+    var invalidTreeSize = 1;
+
+    var thrown =
+        assertThrows(
+            InclusionProofVerificationException.class,
+            () -> {
+              InclusionProofVerifier.verify(
+                  leafHash, logIndex, invalidTreeSize, proofHashes, expectedRootHash);
+            });
+    assertEquals("Inclusion proof failed, ended prematurely", thrown.getMessage());
+  }
+
+  @Test
+  public void verify_rootHashMismatch() throws Exception {
+    var unexpectedRootHash =
+        Hex.decode("effa4fa4575f72829016a64e584441203de533212f9470d63a56d1992e73465e");
+
+    var thrown =
+        assertThrows(
+            InclusionProofVerificationException.class,
+            () -> {
+              InclusionProofVerifier.verify(
+                  leafHash, logIndex, treeSize, proofHashes, unexpectedRootHash);
+            });
+    assertTrue(
+        thrown
+            .getMessage()
+            .startsWith("Calculated inclusion proof root hash does not match provided root hash"));
+  }
+
+  @Test
+  public void hashChildren() {
+    byte[] left = Hex.decode("7170380079683de93335f887309004415054475045b410300586503918910106");
+    byte[] right = Hex.decode("a45db0765e04aa28507698b000d4859f9066055a02895bd8083004890de15892");
+    byte[] expectedParentHash =
+        Hex.decode("467bd65e6c49dbf8f89ddcbf1537aac7a61a7be1b87182393c66ce25050d03c2");
+    assertArrayEquals(expectedParentHash, InclusionProofVerifier.hashChildren(left, right));
+  }
+}

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
@@ -29,8 +29,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.util.encoders.Hex;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,11 +92,7 @@ public class RekorVerifierTest {
     var thrown =
         Assertions.assertThrows(
             RekorVerificationException.class, () -> verifier.verifyEntry(entry));
-
-    MatcherAssert.assertThat(
-        thrown.getMessage(),
-        CoreMatchers.startsWith(
-            "Calculated inclusion proof root hash does not match provided root hash"));
+    Assertions.assertEquals("Inclusion proof verification failed", thrown.getMessage());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #997 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This change extracts the logic for inclusion proof verification into a dedicated library so that it can be used for both Rekor v1 and v2 clients, and potentially other Java clients that need inclusion proof verification outside of Sigstore.