### PR TITLE
Add support for Ed25519 signatures

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/encryption/signers/Ed25519Verifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/signers/Ed25519Verifier.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.encryption.signers;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+
+/** ECDSA verifier, instantiated by {@link Verifiers#newVerifier(PublicKey)}. */
+class Ed25519Verifier implements Verifier {
+
+  private final PublicKey publicKey;
+
+  Ed25519Verifier(PublicKey publicKey) {
+    this.publicKey = publicKey;
+  }
+
+  @Override
+  public PublicKey getPublicKey() {
+    return publicKey;
+  }
+
+  /** Ed25519 verifiers hash implicitly for ed25519 keys. */
+  @Override
+  public boolean verify(byte[] artifact, byte[] signature)
+      throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+    var verifier = Signature.getInstance("Ed25519");
+    verifier.initVerify(publicKey);
+    verifier.update(artifact);
+    return verifier.verify(signature);
+  }
+
+  @Override
+  public boolean verifyDigest(byte[] digest, byte[] signature) {
+    throw new UnsupportedOperationException(
+        "Ed25519 verification requires an artifact, not a digest.");
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/signers/Verifiers.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/signers/Verifiers.java
@@ -17,6 +17,8 @@ package dev.sigstore.encryption.signers;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 
 /** Autodetection for verification algorithms based on public keys used. */
 public class Verifiers {
@@ -28,9 +30,21 @@ public class Verifiers {
     if (publicKey.getAlgorithm().equals("EC") || publicKey.getAlgorithm().equals("ECDSA")) {
       return new EcdsaVerifier(publicKey);
     }
+    if (publicKey.getAlgorithm().equals("Ed25519")) {
+      return new Ed25519Verifier(publicKey);
+    }
+    if (publicKey.getAlgorithm().equals("EdDSA")) {
+      SubjectPublicKeyInfo spki = SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
+      if (spki.getAlgorithm() != null
+          && new ASN1ObjectIdentifier("1.3.101.112").equals(spki.getAlgorithm().getAlgorithm())) {
+        return new Ed25519Verifier(publicKey);
+      }
+      throw new NoSuchAlgorithmException(
+          "Cannot verify signatures for non-Ed25519 EdDSA key types, this client only supports RSA, ECDSA, and Ed25519 verification");
+    }
     throw new NoSuchAlgorithmException(
         "Cannot verify signatures for key type '"
             + publicKey.getAlgorithm()
-            + "', this client only supports RSA and ECDSA verification");
+            + "', this client only supports RSA, ECDSA, and Ed25519 verification");
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/encryption/signers/VerifiersTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/encryption/signers/VerifiersTest.java
@@ -15,33 +15,90 @@
  */
 package dev.sigstore.encryption.signers;
 
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.security.Signature;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 /** VerifiersTest for failure cases, passing cases are handled in {@link SignerTest}. */
 public class VerifiersTest {
+  private static final byte[] CONTENT = "abcdef".getBytes(StandardCharsets.UTF_8);
 
   @Test
-  public void signatureAlgorithm_unknown() throws Exception {
-    var kp = KeyPairGenerator.getInstance("DSA").generateKeyPair();
-    var exception =
-        Assertions.assertThrows(
-            NoSuchAlgorithmException.class, () -> Verifiers.newVerifier(kp.getPublic()));
-    Assertions.assertEquals(
-        exception.getMessage(),
-        "Cannot verify signatures for key type 'DSA', this client only supports RSA and ECDSA verification");
+  public void verify_ed25519_withBcProvider() throws Exception {
+    var kp = genKeyPairWithBcProvider("ed25519");
+    var signature = genSignature(kp, "ed25519");
+    var verifier = Verifiers.newVerifier(kp.getPublic());
+    Assertions.assertTrue(verifier.verify(CONTENT, signature));
   }
 
   @Test
-  public void signatureAlgorithmForDigests_unknown() throws Exception {
+  public void verify_ed25519_withoutBcProvider() throws Exception {
+    var kp = genKeyPair("ed25519");
+    var signature = genSignature(kp, "ed25519");
+    var verifier = Verifiers.newVerifier(kp.getPublic());
+    Assertions.assertTrue(verifier.verify(CONTENT, signature));
+  }
+
+  @Test
+  public void verify_ed448_withBcProvider() throws Exception {
+    var kp = genKeyPairWithBcProvider("ed448");
+    var signature = genSignature(kp, "ed448");
+    var exception =
+        Assertions.assertThrows(
+            NoSuchAlgorithmException.class, () -> Verifiers.newVerifier(kp.getPublic()));
+    Assertions.assertEquals(
+        "Cannot verify signatures for key type 'Ed448', this client only supports RSA, ECDSA, and Ed25519 verification",
+        exception.getMessage());
+  }
+
+  @Test
+  @EnabledForJreRange(min = JRE.JAVA_15)
+  public void verify_ed448_withoutBcProvider() throws Exception {
+    var kp = genKeyPair("ed448");
+    var signature = genSignature(kp, "ed448");
+    var exception =
+        Assertions.assertThrows(
+            NoSuchAlgorithmException.class, () -> Verifiers.newVerifier(kp.getPublic()));
+    Assertions.assertEquals(
+        "Cannot verify signatures for non-Ed25519 EdDSA key types, this client only supports RSA, ECDSA, and Ed25519 verification",
+        exception.getMessage());
+  }
+
+  @Test
+  public void verify_unknown() throws Exception {
     var kp = KeyPairGenerator.getInstance("DSA").generateKeyPair();
     var exception =
         Assertions.assertThrows(
             NoSuchAlgorithmException.class, () -> Verifiers.newVerifier(kp.getPublic()));
     Assertions.assertEquals(
         exception.getMessage(),
-        "Cannot verify signatures for key type 'DSA', this client only supports RSA and ECDSA verification");
+        "Cannot verify signatures for key type 'DSA', this client only supports RSA, ECDSA, and Ed25519 verification");
+  }
+
+  private KeyPair genKeyPair(String algorithm) throws Exception {
+    KeyPairGenerator kpGen = KeyPairGenerator.getInstance(algorithm);
+    return kpGen.generateKeyPair();
+  }
+
+  private KeyPair genKeyPairWithBcProvider(String algorithm) throws Exception {
+    Security.addProvider(new BouncyCastleProvider());
+
+    KeyPairGenerator kpGen = KeyPairGenerator.getInstance(algorithm, "BC");
+    return kpGen.generateKeyPair();
+  }
+
+  private byte[] genSignature(KeyPair keyPair, String algorithm) throws Exception {
+    Signature signature = Signature.getInstance(algorithm);
+    signature.initSign(keyPair.getPrivate());
+    signature.update(CONTENT);
+    return signature.sign();
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #999 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This change adds support for Ed25519 signatures, like the public key of Rekor v2.