### PR TITLE
Add Rekor v2 support to keyless signer and verifier

### DIFF
--- a/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
@@ -18,14 +18,17 @@ package dev.sigstore;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Resources;
+import com.google.gson.JsonParser;
 import dev.sigstore.VerificationOptions.CertificateMatcher;
 import dev.sigstore.bundle.Bundle;
 import dev.sigstore.bundle.ImmutableBundle;
 import dev.sigstore.encryption.signers.Signers;
+import dev.sigstore.rekor.client.RekorVerificationException;
 import dev.sigstore.strings.StringMatcher;
 import dev.sigstore.testing.CertGenerator;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -41,7 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class KeylessVerifierTest {
 
   @Test
-  public void testVerify_noDigestInBundle() throws Exception {
+  public void testVerify_noDigestInBundle_rekorV1() throws Exception {
     var bundleFile =
         Resources.toString(
             Resources.getResource("dev/sigstore/samples/bundles/bundle-no-digest.sigstore"),
@@ -54,7 +57,7 @@ public class KeylessVerifierTest {
   }
 
   @Test
-  public void testVerify_mismatchedSet() throws Exception {
+  public void testVerify_mismatchedSet_rekorV1() throws Exception {
     // a bundle file where the SET is replaced with a valid SET for another artifact
     var bundleFile =
         Resources.toString(
@@ -64,17 +67,23 @@ public class KeylessVerifierTest {
     var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
 
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-    Assertions.assertThrows(
-        KeylessVerificationException.class,
-        () ->
-            verifier.verify(
-                Path.of(artifact),
-                Bundle.from(new StringReader(bundleFile)),
-                VerificationOptions.empty()));
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(bundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertTrue(
+        thrown.getMessage().equals("Transparency log entry could not be verified"));
+    Assertions.assertTrue(thrown.getCause() instanceof RekorVerificationException);
+    Assertions.assertTrue(thrown.getCause().getMessage().equals("Entry SET was not valid"));
   }
 
   @Test
-  public void testVerify_mismatchedArtifactHash() throws Exception {
+  public void testVerify_mismatchedArtifactHash_rekorV1() throws Exception {
     // a bundle file that uses the tlog entry from another artifact signed with the same
     // certificate. The Bundle is fully valid except that the artifact hash doesn't match
     var bundleFile =
@@ -85,17 +94,187 @@ public class KeylessVerifierTest {
     var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
 
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-    Assertions.assertThrows(
-        KeylessVerificationException.class,
-        () ->
-            verifier.verify(
-                Path.of(artifact),
-                Bundle.from(new StringReader(bundleFile)),
-                VerificationOptions.empty()));
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(bundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertTrue(
+        thrown
+            .getMessage()
+            .equals("Provided verification materials are inconsistent with log entry"));
   }
 
   @Test
-  public void testVerify_badCheckpointSignature() throws Exception {
+  public void testVerify_mismatchedArtifactHash_rekorV2() throws Exception {
+    var originalBundleFile =
+        Resources.toString(
+            Resources.getResource(
+                "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore"),
+            StandardCharsets.UTF_8);
+
+    String originalDigestB64 = "oM/HEnHW4njlfNMy/5V8P3BD/do1TEy7GQow1W76Ab8=";
+    String badDigestB64 = "vJJGvv+yDcttb1uHjdvLVmnqDFTtvi/v/3Pvz4Lso0M=";
+
+    var bundle = Bundle.from(new StringReader(originalBundleFile));
+    var canonicalizedBodyB64 = bundle.getEntries().get(0).getBody();
+    var decodedJson =
+        new String(
+            java.util.Base64.getDecoder().decode(canonicalizedBodyB64), StandardCharsets.UTF_8);
+
+    var modifiedJson = decodedJson.replace(originalDigestB64, badDigestB64);
+    var modifiedB64 =
+        java.util.Base64.getEncoder().encodeToString(modifiedJson.getBytes(StandardCharsets.UTF_8));
+    var modifiedBundleFile = originalBundleFile.replace(canonicalizedBodyB64, modifiedB64);
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(modifiedBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertEquals(
+        "Artifact digest does not match digest in log entry spec", thrown.getMessage());
+  }
+
+  @Test
+  public void testVerify_unsupportedDigestAlgorithm_rekorV2() throws Exception {
+    var originalBundleFile =
+        Resources.toString(
+            Resources.getResource(
+                "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore"),
+            StandardCharsets.UTF_8);
+
+    var bundle = Bundle.from(new StringReader(originalBundleFile));
+    var canonicalizedBodyB64 = bundle.getEntries().get(0).getBody();
+    var decodedJson =
+        new String(
+            java.util.Base64.getDecoder().decode(canonicalizedBodyB64), StandardCharsets.UTF_8);
+
+    var root = JsonParser.parseString(decodedJson).getAsJsonObject();
+    root.getAsJsonObject("spec")
+        .getAsJsonObject("hashedRekordV002")
+        .getAsJsonObject("data")
+        .addProperty("algorithm", "SHA1");
+    var modifiedJson = root.toString();
+    var modifiedB64 =
+        java.util.Base64.getEncoder().encodeToString(modifiedJson.getBytes(StandardCharsets.UTF_8));
+    var modifiedBundleFile = originalBundleFile.replace(canonicalizedBodyB64, modifiedB64);
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(modifiedBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertTrue(
+        thrown.getMessage().startsWith("Unsupported digest algorithm in log entry: "));
+  }
+
+  @Test
+  public void testVerify_mismatchedSignature_rekorV2() throws Exception {
+    var originalBundleFile =
+        Resources.toString(
+            Resources.getResource(
+                "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore"),
+            StandardCharsets.UTF_8);
+
+    var bundle = Bundle.from(new StringReader(originalBundleFile));
+    var canonicalizedBodyB64 = bundle.getEntries().get(0).getBody();
+    var decodedJson =
+        new String(
+            java.util.Base64.getDecoder().decode(canonicalizedBodyB64), StandardCharsets.UTF_8);
+
+    String badSignatureB64 =
+        "MEUCIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    var root = JsonParser.parseString(decodedJson).getAsJsonObject();
+    root.getAsJsonObject("spec")
+        .getAsJsonObject("hashedRekordV002")
+        .getAsJsonObject("signature")
+        .addProperty("content", badSignatureB64);
+    var modifiedJson = root.toString();
+
+    var modifiedB64 =
+        java.util.Base64.getEncoder().encodeToString(modifiedJson.getBytes(StandardCharsets.UTF_8));
+    var modifiedBundleFile = originalBundleFile.replace(canonicalizedBodyB64, modifiedB64);
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(modifiedBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertEquals(
+        "Signature does not match signature in log entry spec", thrown.getMessage());
+  }
+
+  @Test
+  public void testVerify_mismatchedCertificate_rekorV2() throws Exception {
+    var originalBundleFile =
+        Resources.toString(
+            Resources.getResource(
+                "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore"),
+            StandardCharsets.UTF_8);
+
+    var bundle = Bundle.from(new StringReader(originalBundleFile));
+    var canonicalizedBodyB64 = bundle.getEntries().get(0).getBody();
+    var decodedJson =
+        new String(
+            java.util.Base64.getDecoder().decode(canonicalizedBodyB64), StandardCharsets.UTF_8);
+
+    String badCertB64 =
+        "MIICAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    var root = JsonParser.parseString(decodedJson).getAsJsonObject();
+    root.getAsJsonObject("spec")
+        .getAsJsonObject("hashedRekordV002")
+        .getAsJsonObject("signature")
+        .getAsJsonObject("verifier")
+        .getAsJsonObject("x509Certificate")
+        .addProperty("rawBytes", badCertB64);
+    var modifiedJson = root.toString();
+
+    var modifiedB64 =
+        java.util.Base64.getEncoder().encodeToString(modifiedJson.getBytes(StandardCharsets.UTF_8));
+    var modifiedBundleFile = originalBundleFile.replace(canonicalizedBodyB64, modifiedB64);
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(modifiedBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertEquals(
+        "Could not parse HashedRekordLogEntryV002 from log entry body", thrown.getMessage());
+  }
+
+  @Test
+  public void testVerify_badCheckpointSignature_rekorV1() throws Exception {
     var bundleFile =
         Resources.toString(
             Resources.getResource(
@@ -104,17 +283,24 @@ public class KeylessVerifierTest {
     var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
 
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-    Assertions.assertThrows(
-        KeylessVerificationException.class,
-        () ->
-            verifier.verify(
-                Path.of(artifact),
-                Bundle.from(new StringReader(bundleFile)),
-                VerificationOptions.empty()));
+
+    var thrown =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(bundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertTrue(
+        thrown.getMessage().equals("Transparency log entry could not be verified"));
+    Assertions.assertTrue(thrown.getCause() instanceof RekorVerificationException);
+    Assertions.assertTrue(
+        thrown.getCause().getMessage().equals("Checkpoint signature was invalid"));
   }
 
   @Test
-  public void testVerify_canVerifyV01Bundle() throws Exception {
+  public void testVerify_canVerifyV01Bundle_rekorV1() throws Exception {
     // note that this v1 bundle contains an inclusion proof
     verifyBundle(
         "dev/sigstore/samples/bundles/artifact.txt",
@@ -122,14 +308,14 @@ public class KeylessVerifierTest {
   }
 
   @Test
-  public void testVerify_canVerifyV02Bundle() throws Exception {
+  public void testVerify_canVerifyV02Bundle_rekorV1() throws Exception {
     verifyBundle(
         "dev/sigstore/samples/bundles/artifact.txt",
         "dev/sigstore/samples/bundles/bundle.v2.sigstore");
   }
 
   @Test
-  public void testVerify_canVerifyV03Bundle() throws Exception {
+  public void testVerify_canVerifyV03Bundle_rekorV1() throws Exception {
     verifyBundle(
         "dev/sigstore/samples/bundles/artifact.txt",
         "dev/sigstore/samples/bundles/bundle.v3.sigstore");
@@ -147,7 +333,7 @@ public class KeylessVerifierTest {
   }
 
   @Test
-  public void verifyWithVerificationOptions() throws Exception {
+  public void verifyWithVerificationOptions_rekorV1() throws Exception {
     var bundleFile =
         Resources.toString(
             Resources.getResource("dev/sigstore/samples/bundles/bundle.sigstore"),
@@ -221,7 +407,7 @@ public class KeylessVerifierTest {
   }
 
   @Test
-  public void testVerify_dsseBundle() throws Exception {
+  public void testVerify_dsseBundle_rekorV1() throws Exception {
     var bundleFile =
         Resources.toString(
             Resources.getResource("dev/sigstore/samples/bundles/bundle.dsse.sigstore"),
@@ -246,7 +432,7 @@ public class KeylessVerifierTest {
 
   @ParameterizedTest
   @MethodSource("badDsseProvider")
-  public void testVerify_dsseBundleBadSignature(String bundleName, String expectedError)
+  public void testVerify_dsseBundleBadSignature_rekorV1(String bundleName, String expectedError)
       throws Exception {
     var bundleFile =
         Resources.toString(
@@ -267,7 +453,7 @@ public class KeylessVerifierTest {
   }
 
   @Test
-  public void testVerify_dsseBundleArtifactNotInSubjects() throws Exception {
+  public void testVerify_dsseBundleArtifactNotInSubjects_rekorV1() throws Exception {
     var bundleFile =
         Resources.toString(
             Resources.getResource("dev/sigstore/samples/bundles/bundle.dsse.sigstore"),
@@ -291,10 +477,85 @@ public class KeylessVerifierTest {
   }
 
   @Test
-  public void testVerify_validRfc3161Timestamp() throws Exception {
-    var artifactUrl = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt");
-    var artifactBytes = Resources.toByteArray(artifactUrl);
-    var artifactDigest = Hashing.sha256().hashBytes(artifactBytes).asBytes();
+  public void testVerify_noTlogEntries_rekorV1() throws Exception {
+    var bundleFile =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/bundles/bundle-with-timestamp.sigstore"),
+            StandardCharsets.UTF_8);
+    var baseBundle = Bundle.from(new StringReader(bundleFile));
+
+    var testBundle = ImmutableBundle.builder().from(baseBundle).entries(List.of()).build();
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    Assertions.assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> verifier.verify(Path.of(artifact), testBundle, VerificationOptions.empty()));
+  }
+
+  @Test
+  public void testVerify_dsseWrongPayloadType_rekorV1() throws Exception {
+    var bundleFile =
+        Files.readString(
+            Path.of(
+                Resources.getResource("dev/sigstore/samples/bundles/bundle.dsse.sigstore")
+                    .toURI()));
+
+    var invalidBundleFile =
+        bundleFile.replace(
+            "\"payloadType\": \"application/vnd.in-toto+json\"",
+            "\"payloadType\": \"application/json\"");
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
+
+    var ex =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(invalidBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertEquals(
+        "DSSE envelope must have payload type application/vnd.in-toto+json, but found 'application/json'",
+        ex.getMessage());
+  }
+
+  @Test
+  public void testVerify_unsupportedRekorVersion_rekorV2() throws Exception {
+    var bundleFile =
+        Files.readString(
+            Path.of(
+                Resources.getResource(
+                        "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore")
+                    .toURI()));
+
+    var invalidBundleFile =
+        bundleFile
+            .replace("\"version\": \"0.0.2\"", "\"version\": \"0.0.3\"")
+            .replace(
+                "eyJhcGlWZXJzaW9uIjoiMC4wLjIi", // base64 of '{"apiVersion":"0.0.2"'
+                "eyJhcGlWZXJzaW9uIjoiMC4wLjMi"); // base64 of '{"apiVersion":"0.0.3"'
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    var ex =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(invalidBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertEquals("Unsupported hashedrekord version", ex.getMessage());
+  }
+
+  @Test
+  public void testVerify_validRfc3161Timestamp_rekorV1() throws Exception {
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
 
     var bundleFile =
         Resources.toString(
@@ -305,77 +566,106 @@ public class KeylessVerifierTest {
     Assertions.assertDoesNotThrow(
         () ->
             verifier.verify(
-                artifactDigest,
+                Path.of(artifact),
                 Bundle.from(new StringReader(bundleFile)),
                 VerificationOptions.empty()));
   }
 
   @Test
-  public void testVerify_invalidRfc3161Timestamp() throws Exception {
+  public void testVerify_canVerifyV03Bundle_rekorV2() throws Exception {
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var bundleFile =
+        Resources.toString(
+            Resources.getResource(
+                "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore"),
+            StandardCharsets.UTF_8);
+
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+    verifier.verify(
+        Path.of(artifact), Bundle.from(new StringReader(bundleFile)), VerificationOptions.empty());
+  }
+
+  @Test
+  public void testVerify_noRfc3161Timestamps_rekorV2() throws Exception {
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var bundleFile =
+        Resources.toString(
+            Resources.getResource(
+                "dev/sigstore/samples/bundles/bundle-with-rekor-v2-entry.sigstore"),
+            StandardCharsets.UTF_8);
+
+    var validRfc3161Timestamps =
+        "\"rfc3161Timestamps\": [{\n"
+            + "        \"signedTimestamp\": \"MIIC1DADAgEAMIICywYJKoZIhvcNAQcCoIICvDCCArgCAQMxDTALBglghkgBZQMEAgEwgcIGCyqGSIb3DQEJEAEEoIGyBIGvMIGsAgEBBgkrBgEEAYO/MAIwMTANBglghkgBZQMEAgEFAAQgtF/jtMHzKroX8UjkT/BViNcIlC5Y7za/y4n5cjasXD0CFQCxAdEfFrtmTuy4mcW7QjLeeOAUXhgPMjAyNTA3MDIxODUxNTFaMAMCAQECCE0pZTAXtl1eoDKkMDAuMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxFTATBgNVBAMTDHNpZ3N0b3JlLXRzYaAAMYIB2zCCAdcCAQEwUTA5MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxIDAeBgNVBAMTF3NpZ3N0b3JlLXRzYS1zZWxmc2lnbmVkAhQKNaEGYdXiQXPGiZan8n3yfgN8pzALBglghkgBZQMEAgGggfwwGgYJKoZIhvcNAQkDMQ0GCyqGSIb3DQEJEAEEMBwGCSqGSIb3DQEJBTEPFw0yNTA3MDIxODUxNTFaMC8GCSqGSIb3DQEJBDEiBCCiICYObTnM098xx9niiVyPo+gxp4FTvN94z4K6gH/LgjCBjgYLKoZIhvcNAQkQAi8xfzB9MHsweQQgBvT/4Ef+s1mZtzOw16MjUBz8GOTAM2aoRdd1NudLJ0QwVTA9pDswOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZAIUCjWhBmHV4kFzxomWp/J98n4DfKcwCgYIKoZIzj0EAwIEZzBlAjB0/hfB4Hm4GO5SZYuDzCtgnNdXQkETtx/QTtILM09awUdez2kQNmCAkLtPBf8ojB8CMQDfRBy5WNohfrWNDh0o+NBR7Yj67vsUyBS1WK5nT5QatouJQ3PbtSJN3Kk8xsiVxFc=\"\n"
+            + "      }]";
+    var noRfc3161Timestamps = "\"rfc3161Timestamps\": []";
+    var invalidBundleFile = bundleFile.replace(validRfc3161Timestamps, noRfc3161Timestamps);
+
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+    var ex =
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(invalidBundleFile)),
+                    VerificationOptions.empty()));
+    Assertions.assertEquals(
+        "No timestamp verification (set, timestamp) was provided", ex.getMessage());
+  }
+
+  @Test
+  public void testVerify_invalidSet_validRfc3161Timestamp_rekorV1() throws Exception {
+    var bundleFileWithTs =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/bundles/bundle-with-timestamp.sigstore"),
+            StandardCharsets.UTF_8);
+
+    var invalidBundleFile =
+        bundleFileWithTs.replace(
+            "\"integratedTime\": \"1747928754\"", "\"integratedTime\": \"1747928000\"");
+
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
+    var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
+
+    var ex =
+        Assertions.assertThrows(
+            KeylessVerificationException.class,
+            () ->
+                verifier.verify(
+                    Path.of(artifact),
+                    Bundle.from(new StringReader(invalidBundleFile)),
+                    VerificationOptions.empty()));
+    MatcherAssert.assertThat(
+        ex.getMessage(), CoreMatchers.equalTo("Transparency log entry could not be verified"));
+    MatcherAssert.assertThat(
+        ex.getCause().getMessage(), CoreMatchers.equalTo("Entry SET was not valid"));
+  }
+
+  @Test
+  public void testVerify_validSet_invalidRfc3161Timestamp_rekorV1() throws Exception {
+    var bundleFile =
+        Resources.toString(
+            Resources.getResource("dev/sigstore/samples/bundles/bundle.v3.sigstore"),
+            StandardCharsets.UTF_8);
+    var baseBundle = Bundle.from(new StringReader(bundleFile));
+
     var tsRespBytesInvalid =
         Resources.toByteArray(
             Resources.getResource(
                 "dev/sigstore/samples/timestamp-response/invalid/sigstore_tsa_response_invalid.tsr"));
 
-    var artifactUrl = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt");
-    var artifactBytes = Resources.toByteArray(artifactUrl);
-    var artifactDigest = Hashing.sha256().hashBytes(artifactBytes).asBytes();
-
-    var bundleFile =
-        Resources.toString(
-            Resources.getResource("dev/sigstore/samples/bundles/bundle.v3.sigstore"),
-            StandardCharsets.UTF_8);
-
-    var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
-
-    var baseBundle = Bundle.from(new StringReader(bundleFile));
     var testBundle =
         ImmutableBundle.builder()
             .from(baseBundle)
             .timestamps(List.of(createTimestamp(tsRespBytesInvalid)))
             .build();
-    var ex =
-        Assertions.assertThrows(
-            KeylessVerificationException.class,
-            () -> verifier.verify(artifactDigest, testBundle, VerificationOptions.empty()));
-    MatcherAssert.assertThat(
-        ex.getMessage(),
-        CoreMatchers.equalTo(
-            "RFC3161 timestamp verification failed: Failed to parse TimeStampResponse"));
-  }
 
-  @Test
-  public void testVerify_invalidTimestampGenTime() throws Exception {
-    var tsRespBytesInvalidGenTime =
-        Resources.toByteArray(
-            Resources.getResource(
-                "dev/sigstore/samples/timestamp-response/valid/sigstore_tsa_response_with_embedded_certs.tsr"));
-
-    var artifactResourcePath = "dev/sigstore/samples/bundles/artifact.txt";
-    var artifactBytes = Resources.toByteArray(Resources.getResource(artifactResourcePath));
-    var artifactDigest = Hashing.sha256().hashBytes(artifactBytes).asBytes();
-
-    var bundleFileContent =
-        Resources.toString(
-            Resources.getResource("dev/sigstore/samples/bundles/bundle.v3.sigstore"),
-            StandardCharsets.UTF_8);
+    var artifact = Resources.getResource("dev/sigstore/samples/bundles/artifact.txt").getPath();
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
 
-    var baseBundle = Bundle.from(new StringReader(bundleFileContent));
-    var testBundle =
-        ImmutableBundle.builder()
-            .from(baseBundle)
-            .timestamps(List.of(createTimestamp(tsRespBytesInvalidGenTime)))
-            .build();
-
-    var ex =
-        Assertions.assertThrows(
-            KeylessVerificationException.class,
-            () -> verifier.verify(artifactDigest, testBundle, VerificationOptions.empty()));
-    MatcherAssert.assertThat(
-        ex.getMessage(),
-        CoreMatchers.startsWith(
-            "RFC3161 timestamp verification failed: Certificates in token were not verifiable against TSAs"));
+    Assertions.assertDoesNotThrow(
+        () -> verifier.verify(Path.of(artifact), testBundle, VerificationOptions.empty()));
   }
 
   private Bundle.Timestamp createTimestamp(byte[] rfc3161Bytes) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
Closes #1002, closes #980, and thus closes #982

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This issue adds support for Rekor v2 in `KeylessSigner` and `KeylessVerifier`.