### PR TITLE
Fix check for empty SET in RekorVerifier

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorVerifier.java
@@ -71,7 +71,8 @@ public class RekorVerifier {
                     new RekorVerificationException(
                         "Log entry (logid) does not match any provided transparency logs."));
 
-    if (entry.getVerification().getSignedEntryTimestamp() != null) {
+    var set = entry.getVerification().getSignedEntryTimestamp();
+    if (set != null && !set.isEmpty()) {
       try {
         var verifier = Verifiers.newVerifier(tlog.getPublicKey().toJavaPublicKey());
         if (!verifier.verify(


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #1019 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change fixes the check for an empty SET in `RekorVerifier` to include an empty string, which is what is read by `BundleReader`. 