### PR TITLE
Move TLogEntry-to-RekorEntry converter to ProtoMutators

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
@@ -20,12 +20,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import dev.sigstore.json.ProtoJson;
+import dev.sigstore.proto.ProtoMutators;
 import dev.sigstore.proto.rekor.v1.TransparencyLogEntry;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 import javax.annotation.Nullable;
-import org.bouncycastle.util.encoders.Hex;
 import org.erdtman.jcs.JsonCanonicalizer;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
@@ -173,49 +173,9 @@ public interface RekorEntry {
     try {
       TransparencyLogEntry.Builder builder = TransparencyLogEntry.newBuilder();
       ProtoJson.parser().ignoringUnknownFields().merge(json, builder);
-      return RekorEntry.fromTLogEntry(builder.build());
+      return ProtoMutators.toRekorEntry(builder.build());
     } catch (InvalidProtocolBufferException e) {
       throw new RekorParseException("Failed to parse Rekor response JSON", e);
     }
-  }
-
-  /** Returns a RekorEntry from a TransparencyLogEntry */
-  public static RekorEntry fromTLogEntry(TransparencyLogEntry tle) throws RekorParseException {
-    ImmutableRekorEntry.Builder builder = ImmutableRekorEntry.builder();
-
-    builder.logIndex(tle.getLogIndex());
-    builder.logID(Hex.toHexString(tle.getLogId().getKeyId().toByteArray()));
-    builder.integratedTime(tle.getIntegratedTime());
-
-    // The body of a RekorEntry is Base64 encoded
-    builder.body(
-        java.util.Base64.getEncoder().encodeToString(tle.getCanonicalizedBody().toByteArray()));
-
-    ImmutableVerification.Builder verificationBuilder = ImmutableVerification.builder();
-
-    // Rekor v2 entries won't have an InclusionPromise/SET
-    if (tle.hasInclusionPromise()
-        && !tle.getInclusionPromise().getSignedEntryTimestamp().isEmpty()) {
-      verificationBuilder.signedEntryTimestamp(
-          java.util.Base64.getEncoder()
-              .encodeToString(tle.getInclusionPromise().getSignedEntryTimestamp().toByteArray()));
-    }
-
-    if (tle.hasInclusionProof()) {
-      dev.sigstore.proto.rekor.v1.InclusionProof ipProto = tle.getInclusionProof();
-      ImmutableInclusionProof.Builder ipBuilder = ImmutableInclusionProof.builder();
-      ipBuilder.logIndex(ipProto.getLogIndex());
-      ipBuilder.rootHash(
-          org.bouncycastle.util.encoders.Hex.toHexString(ipProto.getRootHash().toByteArray()));
-      ipBuilder.treeSize(ipProto.getTreeSize());
-      ipBuilder.checkpoint(ipProto.getCheckpoint().getEnvelope());
-      ipProto
-          .getHashesList()
-          .forEach(hash -> ipBuilder.addHashes(Hex.toHexString(hash.toByteArray())));
-      verificationBuilder.inclusionProof(ipBuilder.build());
-    }
-    builder.verification(verificationBuilder.build());
-
-    return builder.build();
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorEntryTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorEntryTest.java
@@ -17,6 +17,7 @@ package dev.sigstore.rekor.client;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.JsonFormat;
+import dev.sigstore.proto.ProtoMutators;
 import dev.sigstore.proto.common.v1.LogId;
 import dev.sigstore.proto.rekor.v1.Checkpoint;
 import dev.sigstore.proto.rekor.v1.InclusionPromise;
@@ -60,7 +61,7 @@ public class RekorEntryTest {
                     .addHashes(ByteString.fromHex("02")))
             .build();
 
-    var entry = RekorEntry.fromTLogEntry(tle);
+    var entry = ProtoMutators.toRekorEntry(tle);
 
     Assertions.assertEquals(123, entry.getLogIndex());
     Assertions.assertEquals("abcdef", entry.getLogID());
@@ -94,7 +95,7 @@ public class RekorEntryTest {
             .setCanonicalizedBody(MOCK_BODY_BYTESTRING)
             .build();
 
-    var entry = RekorEntry.fromTLogEntry(tle);
+    var entry = ProtoMutators.toRekorEntry(tle);
     Assertions.assertEquals(123, entry.getLogIndex());
     Assertions.assertEquals("abcdef", entry.getLogID());
     Assertions.assertEquals(456, entry.getIntegratedTime());

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorVerifierTest.java
@@ -21,6 +21,7 @@ import com.google.common.io.Resources;
 import com.google.protobuf.InvalidProtocolBufferException;
 import dev.sigstore.json.GsonSupplier;
 import dev.sigstore.json.ProtoJson;
+import dev.sigstore.proto.ProtoMutators;
 import dev.sigstore.proto.rekor.v1.TransparencyLogEntry;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
 import java.io.IOException;
@@ -280,7 +281,7 @@ public class RekorVerifierTest {
       throws InvalidProtocolBufferException, RekorParseException {
     var transparencyLogEntryBuilder = TransparencyLogEntry.newBuilder();
     ProtoJson.parser().merge(json, transparencyLogEntryBuilder);
-    return RekorEntry.fromTLogEntry(transparencyLogEntryBuilder.build());
+    return ProtoMutators.toRekorEntry(transparencyLogEntryBuilder.build());
   }
 
   private RekorEntry getV1RekorEntry(String json) throws Exception {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This changes moves a method that converts a `TransparencyLogEntry` proto object into a `RekorEntry` Java object into the relevant `ProtoMutators` so as to avoid exposing a proto object.