### PR TITLE
Match signer chosing to algorithm registry

### DIFF
--- a/fuzzing/src/main/java/fuzzing/SignerVerifierFuzzer.java
+++ b/fuzzing/src/main/java/fuzzing/SignerVerifierFuzzer.java
@@ -16,6 +16,7 @@
 package fuzzing;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.encryption.signers.Signer;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.encryption.signers.Verifier;
@@ -27,10 +28,10 @@ import java.security.SignatureException;
 public class SignerVerifierFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     try {
-      Integer choice = data.consumeInt(0, 1);
+      Integer choice = data.consumeInt(0, AlgorithmRegistry.SigningAlgorithm.values().length - 1);
       byte[] byteArray = data.consumeRemainingAsBytes();
 
-      Signer signer = (choice == 1) ? Signers.newEcdsaSigner() : Signers.newRsaSigner();
+      Signer signer = Signers.from(AlgorithmRegistry.SigningAlgorithm.values()[choice]);
       Verifier verifier = Verifiers.newVerifier(signer.getPublicKey());
 
       byte[] signature1 = signer.sign(byteArray);

--- a/sigstore-java/src/main/java/dev/sigstore/AlgorithmRegistry.java
+++ b/sigstore-java/src/main/java/dev/sigstore/AlgorithmRegistry.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore;
+
+import static com.google.common.hash.Hashing.*;
+
+import com.google.common.hash.HashFunction;
+
+public class AlgorithmRegistry {
+  public enum SigningAlgorithm {
+    PKIX_RSA_PKCS1V15_2048_SHA256(HashAlgorithm.SHA2_256),
+    PKIX_RSA_PKCS1V15_3072_SHA256(HashAlgorithm.SHA2_256),
+    PKIX_RSA_PKCS1V15_4096_SHA256(HashAlgorithm.SHA2_256),
+
+    // ECDSA
+    PKIX_ECDSA_P256_SHA_256(HashAlgorithm.SHA2_256);
+    // TODO: PKIX_ECDSA_P384_SHA_384(HashAlgorithm.SHA2_384),
+    // TODO: PKIX_ECDSA_P521_SHA_512(HashAlgorithm.SHA2_512);
+
+    private final HashAlgorithm hashAlgorithm;
+
+    SigningAlgorithm(HashAlgorithm hashAlgorithm) {
+      this.hashAlgorithm = hashAlgorithm;
+    }
+
+    public HashAlgorithm getHashing() {
+      return hashAlgorithm;
+    }
+  }
+
+  public enum HashAlgorithm {
+    SHA2_256("SHA256", 32, sha256());
+    // TODO: SHA2_384("SHA384", 48, sha384()),
+    // TODO: SHA2_512("SHA512", 64, sha512());
+
+    private final String name;
+    private final int length;
+    private final HashFunction hashFunction;
+
+    HashAlgorithm(String name, int length, HashFunction hashFunction) {
+      this.name = name;
+      this.length = length;
+      this.hashFunction = hashFunction;
+    }
+
+    public String toString() {
+      return name;
+    }
+
+    public int getLength() {
+      return length;
+    }
+
+    HashFunction getHashFunction() {
+      return hashFunction;
+    }
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/Bundle.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/Bundle.java
@@ -16,6 +16,7 @@
 package dev.sigstore.bundle;
 
 import com.google.common.base.Preconditions;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.rekor.client.RekorEntry;
 import java.io.IOException;
 import java.io.Reader;
@@ -39,10 +40,6 @@ import org.immutables.value.Value.Lazy;
  */
 @Immutable
 public abstract class Bundle {
-
-  public enum HashAlgorithm {
-    SHA2_256
-  }
 
   static final String BUNDLE_V_0_1 = "application/vnd.dev.sigstore.bundle+json;version=0.1";
   static final String BUNDLE_V_0_2 = "application/vnd.dev.sigstore.bundle+json;version=0.2";
@@ -112,7 +109,8 @@ public abstract class Bundle {
     /** Signature over an artifact. */
     byte[] getSignature();
 
-    static MessageSignature of(HashAlgorithm algorithm, byte[] digest, byte[] signature) {
+    static MessageSignature of(
+        AlgorithmRegistry.HashAlgorithm algorithm, byte[] digest, byte[] signature) {
       return ImmutableMessageSignature.builder()
           .signature(signature)
           .messageDigest(
@@ -125,7 +123,7 @@ public abstract class Bundle {
   public interface MessageDigest {
 
     /** The algorithm used to compute the digest. */
-    HashAlgorithm getHashAlgorithm();
+    AlgorithmRegistry.HashAlgorithm getHashAlgorithm();
 
     /**
      * The raw bytes of the digest computer using the hashing algorithm described by {@link

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleReader.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleReader.java
@@ -16,6 +16,7 @@
 package dev.sigstore.bundle;
 
 import com.google.protobuf.ByteString;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.json.ProtoJson;
 import dev.sigstore.proto.ProtoMutators;
 import dev.sigstore.proto.common.v1.HashAlgorithm;
@@ -126,7 +127,7 @@ class BundleReader {
             ImmutableMessageSignature.builder()
                 .messageDigest(
                     ImmutableMessageDigest.builder()
-                        .hashAlgorithm(Bundle.HashAlgorithm.SHA2_256)
+                        .hashAlgorithm(AlgorithmRegistry.HashAlgorithm.SHA2_256)
                         .digest(
                             protoBundle
                                 .getMessageSignature()

--- a/sigstore-java/src/main/java/dev/sigstore/bundle/BundleWriter.java
+++ b/sigstore-java/src/main/java/dev/sigstore/bundle/BundleWriter.java
@@ -94,7 +94,7 @@ class BundleWriter {
                 .setMessageDigest(
                     HashOutput.newBuilder()
                         .setAlgorithm(
-                            ProtoMutators.from(
+                            ProtoMutators.toProtoHashAlgorithm(
                                 messageSignature.getMessageDigest().get().getHashAlgorithm()))
                         .setDigest(
                             ByteString.copyFrom(

--- a/sigstore-java/src/main/java/dev/sigstore/encryption/signers/Signers.java
+++ b/sigstore-java/src/main/java/dev/sigstore/encryption/signers/Signers.java
@@ -15,29 +15,46 @@
  */
 package dev.sigstore.encryption.signers;
 
+import dev.sigstore.AlgorithmRegistry;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.spec.ECGenParameterSpec;
 
 /** Factory class for creation of signers. */
 public class Signers {
 
-  /** Create a new ECDSA signer with 256 bit keysize. */
-  public static EcdsaSigner newEcdsaSigner() {
+  /** Create a new signer from the algorithm registry. */
+  public static Signer from(AlgorithmRegistry.SigningAlgorithm algorithm) {
+    switch (algorithm) {
+      case PKIX_RSA_PKCS1V15_2048_SHA256:
+        return newRsaSigner(2048, AlgorithmRegistry.HashAlgorithm.SHA2_256);
+      case PKIX_RSA_PKCS1V15_3072_SHA256:
+        return newRsaSigner(3072, AlgorithmRegistry.HashAlgorithm.SHA2_256);
+      case PKIX_RSA_PKCS1V15_4096_SHA256:
+        return newRsaSigner(4096, AlgorithmRegistry.HashAlgorithm.SHA2_256);
+      case PKIX_ECDSA_P256_SHA_256:
+        return newEcdsaSigner("secp256r1", AlgorithmRegistry.HashAlgorithm.SHA2_256);
+    }
+    throw new IllegalStateException("Unknown algorithm: " + algorithm);
+  }
+
+  static EcdsaSigner newEcdsaSigner(String spec, AlgorithmRegistry.HashAlgorithm hashAlgorithm) {
     try {
       KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
-      keyGen.initialize(256);
-      return new EcdsaSigner(keyGen.generateKeyPair());
-    } catch (NoSuchAlgorithmException nse) {
+      keyGen.initialize(new ECGenParameterSpec(spec));
+      return new EcdsaSigner(keyGen.generateKeyPair(), hashAlgorithm);
+    } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException nse) {
       throw new RuntimeException("No EC algorithm found in Runtime", nse);
     }
   }
 
   /** Create a new RSA signer with 2048 bit keysize. */
-  public static RsaSigner newRsaSigner() {
+  static RsaSigner newRsaSigner(int keysize, AlgorithmRegistry.HashAlgorithm hashAlgorithm) {
     try {
       KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
-      keyGen.initialize(2048);
-      return new RsaSigner(keyGen.generateKeyPair());
+      keyGen.initialize(keysize);
+      return new RsaSigner(keyGen.generateKeyPair(), hashAlgorithm);
     } catch (NoSuchAlgorithmException nse) {
       throw new RuntimeException("No RSA algorithm found in Runtime", nse);
     }

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -17,7 +17,6 @@ package dev.sigstore;
 
 import com.google.common.hash.Hashing;
 import dev.sigstore.bundle.Bundle;
-import dev.sigstore.bundle.Bundle.HashAlgorithm;
 import dev.sigstore.testkit.annotations.DisabledIfSkipStaging;
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists;
 import dev.sigstore.testkit.annotations.OidcProviderType;
@@ -108,7 +107,7 @@ public class KeylessTest {
       Assertions.assertArrayEquals(
           artifactDigest, result.getMessageSignature().get().getMessageDigest().get().getDigest());
       Assertions.assertEquals(
-          HashAlgorithm.SHA2_256,
+          AlgorithmRegistry.HashAlgorithm.SHA2_256,
           result.getMessageSignature().get().getMessageDigest().get().getHashAlgorithm());
       // check if required inclusion proof exists
       Assertions.assertNotNull(result.getEntries().get(0).getVerification().getInclusionProof());

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
@@ -357,7 +357,10 @@ public class KeylessVerifierTest {
   public void verifyCertificateMatches_noneProvided() throws Exception {
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
     var certificate =
-        (X509Certificate) CertGenerator.newCert(Signers.newEcdsaSigner().getPublicKey());
+        (X509Certificate)
+            CertGenerator.newCert(
+                Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256)
+                    .getPublicKey());
     Assertions.assertDoesNotThrow(() -> verifier.checkCertificateMatchers(certificate, List.of()));
   }
 
@@ -365,7 +368,10 @@ public class KeylessVerifierTest {
   public void verifyCertificateMatches_anyOf() throws Exception {
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
     var certificate =
-        (X509Certificate) CertGenerator.newCert(Signers.newEcdsaSigner().getPublicKey());
+        (X509Certificate)
+            CertGenerator.newCert(
+                Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256)
+                    .getPublicKey());
     Assertions.assertDoesNotThrow(
         () ->
             verifier.checkCertificateMatchers(
@@ -385,7 +391,10 @@ public class KeylessVerifierTest {
   public void verifyCertificateMatches_noneMatch() throws Exception {
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
     var certificate =
-        (X509Certificate) CertGenerator.newCert(Signers.newEcdsaSigner().getPublicKey());
+        (X509Certificate)
+            CertGenerator.newCert(
+                Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256)
+                    .getPublicKey());
     var ex =
         Assertions.assertThrows(
             KeylessVerificationException.class,

--- a/sigstore-java/src/test/java/dev/sigstore/encryption/signers/SignerTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/encryption/signers/SignerTest.java
@@ -16,6 +16,7 @@
 package dev.sigstore.encryption.signers;
 
 import com.google.common.hash.Hashing;
+import dev.sigstore.AlgorithmRegistry;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.stream.Stream;
@@ -30,10 +31,17 @@ public class SignerTest {
   private static final byte[] CONTENT_DIGEST = Hashing.sha256().hashBytes(CONTENT).asBytes();
 
   static Stream<Arguments> signerProvider() throws NoSuchAlgorithmException {
-    var rsaSigner = Signers.newRsaSigner();
-    var ecdsaSigner = Signers.newEcdsaSigner();
+    var rsaSigner2048 =
+        Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_2048_SHA256);
+    var rsaSigner3072 =
+        Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_3072_SHA256);
+    var rsaSigner4096 =
+        Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_4096_SHA256);
+    var ecdsaSigner = Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256);
     return Stream.of(
-        Arguments.arguments(rsaSigner, Verifiers.newVerifier(rsaSigner.getPublicKey())),
+        Arguments.arguments(rsaSigner2048, Verifiers.newVerifier(rsaSigner2048.getPublicKey())),
+        Arguments.arguments(rsaSigner3072, Verifiers.newVerifier(rsaSigner3072.getPublicKey())),
+        Arguments.arguments(rsaSigner4096, Verifiers.newVerifier(rsaSigner4096.getPublicKey())),
         Arguments.arguments(ecdsaSigner, Verifiers.newVerifier(ecdsaSigner.getPublicKey())));
   }
 

--- a/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioCertificateMatcherTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioCertificateMatcherTest.java
@@ -17,6 +17,7 @@ package dev.sigstore.fulcio.client;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.VerificationOptions.UncheckedCertificateException;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.encryption.signers.Signers;
@@ -36,7 +37,11 @@ public class FulcioCertificateMatcherTest {
 
   @BeforeAll
   public static void createCertificate() throws Exception {
-    certificate = (X509Certificate) CertGenerator.newCert(Signers.newEcdsaSigner().getPublicKey());
+    certificate =
+        (X509Certificate)
+            CertGenerator.newCert(
+                Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256)
+                    .getPublicKey());
   }
 
   @Test

--- a/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioClientGrpcTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/fulcio/client/FulcioClientGrpcTest.java
@@ -16,6 +16,7 @@
 package dev.sigstore.fulcio.client;
 
 import com.google.common.io.Resources;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.http.HttpParams;
@@ -41,7 +42,7 @@ public class FulcioClientGrpcTest {
     var token = mockOAuthServerExtension.getOidcToken().getIdToken();
     var subject = mockOAuthServerExtension.getOidcToken().getSubjectAlternativeName();
 
-    var signer = Signers.newEcdsaSigner();
+    var signer = Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256);
     var signed = signer.sign(subject.getBytes(StandardCharsets.UTF_8));
 
     // create a certificate request with our public key and our signed "subject"
@@ -71,7 +72,7 @@ public class FulcioClientGrpcTest {
     var token = mockOAuthServerExtension.getOidcToken().getIdToken();
     var subject = mockOAuthServerExtension.getOidcToken().getSubjectAlternativeName();
 
-    var signer = Signers.newRsaSigner();
+    var signer = Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_2048_SHA256);
     var signed = signer.sign(subject.getBytes(StandardCharsets.UTF_8));
 
     // create a certificate request with our public key and our signed "subject"

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientHttpTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientHttpTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.encryption.certificates.Certificates;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.testing.CertGenerator;
@@ -180,7 +181,7 @@ public class RekorClientHttpTest {
         MessageDigest.getInstance("SHA-256").digest(data.getBytes(StandardCharsets.UTF_8));
 
     // sign the full content (these signers do the artifact hashing themselves)
-    var signer = Signers.newEcdsaSigner();
+    var signer = Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256);
     var signature = signer.sign(data.getBytes(StandardCharsets.UTF_8));
 
     // create a fake signing cert (not fulcio/dex)

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/v2/client/RekorV2ClientHttpTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/v2/client/RekorV2ClientHttpTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
+import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.encryption.signers.Signers;
 import dev.sigstore.proto.common.v1.PublicKeyDetails;
 import dev.sigstore.proto.common.v1.X509Certificate;
@@ -83,7 +84,7 @@ public class RekorV2ClientHttpTest {
         MessageDigest.getInstance("SHA-256").digest(data.getBytes(StandardCharsets.UTF_8));
 
     // sign the full content (these signers do the artifact hashing themselves)
-    var signer = Signers.newEcdsaSigner();
+    var signer = Signers.from(AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256);
     var signatureBytes = signer.sign(data.getBytes(StandardCharsets.UTF_8));
 
     // create a fake signing cert (not fulcio/dex)


### PR DESCRIPTION
#### Summary
Start integrating algorithm registry into sigstore-java. 

`KeylessSigner.signer(any impl)` is now replaced with `KeylessSigner.singer(AlgorithmRegistry.SigningAlgorithm)`

No changes were made to how verification parses and operates on keys

Sigstore java still requires sha256 as the hashing algorithm across operations.

#### Release Note

#### Documentation
