### PR TITLE
Require signing config from TUF and remove legacy fallback

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -62,7 +62,6 @@ import dev.sigstore.timestamp.client.TimestampException;
 import dev.sigstore.timestamp.client.TimestampResponse;
 import dev.sigstore.timestamp.client.TimestampVerificationException;
 import dev.sigstore.timestamp.client.TimestampVerifier;
-import dev.sigstore.trustroot.LegacySigningConfig;
 import dev.sigstore.trustroot.Service;
 import dev.sigstore.trustroot.SigstoreConfigurationException;
 import dev.sigstore.tuf.SigstoreTufClient;
@@ -359,10 +358,7 @@ public class KeylessSigner implements AutoCloseable {
     public Builder sigstorePublicDefaults() {
       var sigstoreTufClientBuilder = SigstoreTufClient.builder().usePublicGoodInstance();
       trustedRootProvider = TrustedRootProvider.from(sigstoreTufClientBuilder);
-      // TODO: signing config is not pushed to prod yet
-      signingConfigProvider =
-          SigningConfigProvider.fromOrDefault(
-              sigstoreTufClientBuilder, LegacySigningConfig.PUBLIC_GOOD);
+      signingConfigProvider = SigningConfigProvider.from(sigstoreTufClientBuilder);
       signingAlgorithm = AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256;
       minSigningCertificateLifetime(DEFAULT_MIN_SIGNING_CERTIFICATE_LIFETIME);
       return this;

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -30,7 +30,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.time.Instant;
-import javax.annotation.Nullable;
 
 /**
  * Wrapper around {@link dev.sigstore.tuf.Updater} that provides access to sigstore specific
@@ -48,10 +47,7 @@ public class SigstoreTufClient {
   private final Updater updater;
   private Instant lastUpdate;
   private SigstoreTrustedRoot sigstoreTrustedRoot;
-  // TODO: this is nullable because we expect all future sigstore tuf repos to contain a signing
-  // config
-  // but while we transition, we need to handle the null case.
-  @Nullable private SigstoreSigningConfig sigstoreSigningConfig;
+  private SigstoreSigningConfig sigstoreSigningConfig;
   private final Duration cacheValidity;
 
   @VisibleForTesting
@@ -181,15 +177,9 @@ public class SigstoreTufClient {
       throw new SigstoreConfigurationException("Failed to read trusted root from target store", ex);
     }
     try {
-      if (updater.getTargetStore().hasTarget(SIGNING_CONFIG_FILENAME)) {
-        sigstoreSigningConfig =
-            SigstoreSigningConfig.from(
-                updater.getTargetStore().getTargetInputSteam(SIGNING_CONFIG_FILENAME));
-      } else {
-        sigstoreSigningConfig = null;
-        // TODO: Remove when prod and staging TUF repos have fully configured signing configs, but
-        // right now sigstore tuf repos not having sigstoreSigningConfig is a valid state.
-      }
+      sigstoreSigningConfig =
+          SigstoreSigningConfig.from(
+              updater.getTargetStore().getTargetInputSteam(SIGNING_CONFIG_FILENAME));
     } catch (IOException ex) {
       throw new SigstoreConfigurationException(
           "Failed to read signing config from target store", ex);
@@ -200,7 +190,6 @@ public class SigstoreTufClient {
     return sigstoreTrustedRoot;
   }
 
-  @Nullable
   public SigstoreSigningConfig getSigstoreSigningConfig() {
     return sigstoreSigningConfig;
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change requires a signing config from TUF and removes fallback logic meant to handle a null signing config, now that the signing config has been pushed to prod.