### PR TITLE
fix: Get Rekor v2 from signing config if enabled

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -288,7 +288,7 @@ public class KeylessSigner implements AutoCloseable {
       var fulcioVerifier = FulcioVerifier.newFulcioVerifier(trustedRoot);
 
       var rekorService =
-          Service.select(signingConfig.getTLogs(), enableRekorV2 ? List.of(1) : List.of(1, 2));
+          Service.select(signingConfig.getTLogs(), enableRekorV2 ? List.of(1, 2) : List.of(1));
       if (rekorService.isEmpty()) {
         throw new SigstoreConfigurationException(
             "No suitable rekor target was found in signing config");


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This changes fixes an inverse in the condition in `KeylessSigner` that is used to get Rekor v2 from the signing config if enabled.