### PR TITLE
fix(test): Verify signing result for Rekor v1 vs. v2

### DIFF
--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -64,7 +64,7 @@ public class KeylessTest {
     var signer = KeylessSigner.builder().sigstorePublicDefaults().build();
     var results = signer.sign(artifactDigests);
 
-    verifySigningResult(results);
+    verifySigningResult(results, false);
 
     var verifier = KeylessVerifier.builder().sigstorePublicDefaults().build();
     for (int i = 0; i < results.size(); i++) {
@@ -81,7 +81,7 @@ public class KeylessTest {
     var signer =
         KeylessSigner.builder().sigstoreStagingDefaults().enableRekorV2(enableRekorV2).build();
     var results = signer.sign(artifactDigests);
-    verifySigningResult(results);
+    verifySigningResult(results, enableRekorV2);
 
     var verifier = KeylessVerifier.builder().sigstoreStagingDefaults().build();
     for (int i = 0; i < results.size(); i++) {
@@ -90,7 +90,7 @@ public class KeylessTest {
     }
   }
 
-  private void verifySigningResult(List<Bundle> results) throws IOException {
+  private void verifySigningResult(List<Bundle> results, boolean enableRekorV2) throws IOException {
 
     Assertions.assertEquals(artifactDigests.size(), results.size());
 
@@ -111,6 +111,14 @@ public class KeylessTest {
           result.getMessageSignature().get().getMessageDigest().get().getHashAlgorithm());
       // check if required inclusion proof exists
       Assertions.assertNotNull(result.getEntries().get(0).getVerification().getInclusionProof());
+
+      if (enableRekorV2) {
+        Assertions.assertEquals(
+            "0.0.2", result.getEntries().get(0).getBodyDecoded().getApiVersion());
+      } else {
+        Assertions.assertEquals(
+            "0.0.1", result.getEntries().get(0).getBodyDecoded().getApiVersion());
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change updates the mechanism for verifying the signing result in `KeylessTest` to check if the API version matches the version of Rekor enabled.