### PR TITLE
Configure maven central publishing

### DIFF
--- a/.github/workflows/release-sigstore-java-from-tag.yaml
+++ b/.github/workflows/release-sigstore-java-from-tag.yaml
@@ -57,14 +57,29 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v0.8.1
+        with:
+          workload_identity_provider: projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
+          service_account: sigstore-java-releaser@sigstore-secrets.iam.gserviceaccount.com
+
+      - uses: google-github-actions/get-secretmanager-secrets@a8440875e1c2892062aef9061228d4f1af8f919b # v2.2.3
+        id: secrets
+        with:
+          secrets: |-
+            signing_key:sigstore-secrets/sigstore-java-pgp-priv-key
+            signing_password:sigstore-secrets/sigstore-java-pgp-priv-key-password
+            sonatype_username:sigstore-secrets/sigstore-sonatype-central-portal-username
+            sonatype_password:sigstore-secrets/sigstore-sonatype-central-portal-password
+
       - name: Build, Sign and Release to Maven Central
-        run: |
-          ./gradlew clean :sigstore-java:publishMavenJavaPublicationToSonatypeRepository :sigstore-maven-plugin:publishMavenJavaPublicationToSonatypeRepository -Prelease
         env:
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ steps.secrets.outputs.signing_key }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ steps.secrets.outputs.signing_password }}
+          CENTRAL_PORTAL_USERNAME: ${{ steps.secrets.outputs.sonatype_username }}
+          CENTRAL_PORTAL_PASSWORD: ${{ steps.secrets.outputs.sonatype_password }}
+        run: |
+          ./gradlew clean :publishAggregationToCentralPortal -Prelease
 
   create-release-on-github:
     runs-on: ubuntu-latest

--- a/build-logic/publishing/build.gradle.kts
+++ b/build-logic/publishing/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     implementation("dev.sigstore.build-logic:gradle-plugin")
     implementation("dev.sigstore:sigstore-gradle-sign-plugin:1.3.0")
     implementation("com.gradle.plugin-publish:com.gradle.plugin-publish.gradle.plugin:1.3.1")
+    implementation("com.gradleup.nmcp:com.gradleup.nmcp.gradle.plugin:1.0.2")
 }

--- a/build-logic/publishing/src/main/kotlin/build-logic.publish-to-central.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.publish-to-central.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("java-library")
     id("maven-publish")
+    id("com.gradleup.nmcp")
     id("build-logic.publish-to-tmp-maven-repo")
 }
 
@@ -57,13 +58,6 @@ publishing {
                 url.set(repoUrl)
                 tag.set("HEAD")
             }
-        }
-    }
-    repositories {
-        maven {
-            name = "sonatype"
-            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials(PasswordCredentials::class)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("build-logic.root-build")
+    id("com.gradleup.nmcp.aggregation") version "1.0.2"
     // The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
     `embedded-kotlin` apply false
 }
@@ -14,4 +15,18 @@ val parameters by tasks.registering {
     group = HelpTasksPlugin.HELP_GROUP
     description = "Displays build parameters (i.e. -P flags) that can be used to customize the build"
     dependsOn(gradle.includedBuild("build-logic").task(":build-parameters:parameters"))
+}
+
+nmcpAggregation {
+    centralPortal {
+        username = providers.environmentVariable("CENTRAL_PORTAL_USERNAME")
+        password = providers.environmentVariable("CENTRAL_PORTAL_PASSWORD")
+        publishingType = "USER_MANAGED"
+        publicationName = "sigstore protobuf-specs $version"
+    }
+}
+
+dependencies {
+    nmcpAggregation(project(":sigstore-java"))
+    nmcpAggregation(project(":sigstore-maven-plugin"))
 }

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
@@ -37,6 +37,7 @@ import dev.sigstore.http.HttpClients;
 import dev.sigstore.http.HttpParams;
 import dev.sigstore.trustroot.Service;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
@@ -93,6 +94,13 @@ public class WebOidcClient implements OidcClient {
     /** The issuer of the oidc tokens (the oidc service). */
     public Builder setIssuer(Service issuer) {
       this.issuer = issuer;
+      return this;
+    }
+
+    /** Deprecated compat issuer selector, remove in next version. */
+    @Deprecated
+    public Builder setIssuer(String issuer) {
+      this.issuer = Service.of(URI.create(issuer), 1);
       return this;
     }
 


### PR DESCRIPTION
should consume secrets from gcp during publishing. Note that this means we have moved our pgp key to something else and we *must* document that releases 2.x onwards use the new key.