### PR TITLE
fix: Reject unsupported DSSE version

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
@@ -339,7 +339,7 @@ public class KeylessVerifier {
             "Could not encode leaf certificate for comparison", e);
       }
     } else {
-      throw new KeylessVerificationException("Unsupported hashedrekord version");
+      throw new KeylessVerificationException("Unsupported hashedrekord version: " + version);
     }
   }
 
@@ -505,6 +505,8 @@ public class KeylessVerifier {
         throw new KeylessVerificationException(
             "Could not encode leaf certificate for comparison", e);
       }
+    } else {
+      throw new KeylessVerificationException("Unsupported DSSE version: " + version);
     }
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
@@ -573,7 +573,7 @@ public class KeylessVerifierTest {
                     Path.of(artifact),
                     Bundle.from(new StringReader(invalidBundleFile)),
                     VerificationOptions.empty()));
-    Assertions.assertEquals("Unsupported hashedrekord version", ex.getMessage());
+    Assertions.assertEquals("Unsupported hashedrekord version: 0.0.3", ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change adds an exception that is thrown when the version of a DSSE envelope in a Rekor entry is unsupported.