### PR TITLE
ref: Simplify hashedrekord and DSSE parsing exceptions

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessVerifier.java
@@ -305,8 +305,7 @@ public class KeylessVerifier {
                 builder);
         logEntrySpec = builder.build();
       } catch (InvalidProtocolBufferException ipbe) {
-        throw new KeylessVerificationException(
-            "Could not parse HashedRekordLogEntryV002 from log entry body");
+        throw new KeylessVerificationException("Could not parse hashedrekord from log entry body");
       }
 
       if (!logEntrySpec.getData().getAlgorithm().equals(HashAlgorithm.SHA2_256)) {
@@ -460,8 +459,7 @@ public class KeylessVerifier {
                 builder);
         logEntrySpec = builder.build();
       } catch (InvalidProtocolBufferException ipbe) {
-        throw new KeylessVerificationException(
-            "Could not parse DSSELogEntryV002 from log entry body", ipbe);
+        throw new KeylessVerificationException("Could not parse DSSE from log entry body", ipbe);
       }
 
       if (!logEntrySpec.getPayloadHash().getAlgorithm().equals(HashAlgorithm.SHA2_256)) {

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessVerifierTest.java
@@ -270,7 +270,7 @@ public class KeylessVerifierTest {
                     Bundle.from(new StringReader(modifiedBundleFile)),
                     VerificationOptions.empty()));
     Assertions.assertEquals(
-        "Could not parse HashedRekordLogEntryV002 from log entry body", thrown.getMessage());
+        "Could not parse hashedrekord from log entry body", thrown.getMessage());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change simplifies the exceptions thrown during keyless verification when the hashedrekord or DSSE could not be parsed from a log entry body.