### PR TITLE
Fix userAgent string in requests

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/WebOidcClient.java
@@ -164,6 +164,8 @@ public class WebOidcClient implements OidcClient {
                 endpoints.getAuthEndpoint())
             .enablePKCE()
             .setScopes(Arrays.asList("openid", "email"))
+            .setRequestInitializer(
+                (req) -> req.getHeaders().set("User-Agent", httpParams.getUserAgent()))
             .setCredentialCreatedListener(
                 (credential, tokenResponse) ->
                     memStoreFactory


### PR DESCRIPTION
fixes #1065 , looks like this either changed or was never working.

New requests to staging are using the java user-agent again according to logs