### PR TITLE
chore: remove commons-codec dependency from sigstore-java

### DIFF
--- a/sigstore-cli/src/main/java/dev/sigstore/cli/Verify.java
+++ b/sigstore-cli/src/main/java/dev/sigstore/cli/Verify.java
@@ -18,6 +18,7 @@ package dev.sigstore.cli;
 import static com.google.common.io.Files.asByteSource;
 
 import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
 import dev.sigstore.KeylessVerifier;
 import dev.sigstore.TrustedRootProvider;
 import dev.sigstore.VerificationOptions;
@@ -30,7 +31,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
-import org.apache.commons.codec.binary.Hex;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -117,7 +117,8 @@ public class Verify implements Callable<Integer> {
   public Integer call() throws Exception {
     byte[] digest;
     if (artifact.startsWith(SHA256_PREFIX)) {
-      digest = Hex.decodeHex(artifact.substring(SHA256_PREFIX.length()));
+      digest =
+          BaseEncoding.base16().ignoreCase().decode(artifact.substring(SHA256_PREFIX.length()));
     } else {
       if (workingDirectory != null) {
         artifact = workingDirectory.resolve(artifact).toString();

--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -11,6 +11,10 @@ plugins {
 description = "A Java client for signing and verifying using Sigstore"
 
 dependencies {
+    constraints {
+        // Just in case third-party dependencies use it
+        implementation("commons-codec:commons-codec:1.20.0")
+    }
     compileOnly("org.immutables:gson:2.10.1")
     compileOnly("org.immutables:value-annotations:2.10.1")
     annotationProcessor("org.immutables:value:2.10.1")
@@ -34,7 +38,6 @@ dependencies {
     runtimeOnly("io.grpc:grpc-netty-shaded")
     compileOnly("org.apache.tomcat:annotations-api:6.0.53") // java 9+ only
 
-    implementation("commons-codec:commons-codec:1.18.0")
     implementation("com.google.code.gson:gson:2.13.2")
     implementation("org.bouncycastle:bcutil-jdk18on:1.82")
     implementation("org.bouncycastle:bcpkix-jdk18on:1.82")


### PR DESCRIPTION
`commons-codec` might still be used as a transitive, however, the base code should not rely on commons.

Modern Java is good enough so we do not need `commons-*` in the runtime classpath.

`HexFormat` requries Java 17, so let's go with Guava's `BaseEncoding` for now.
