### PR TITLE
test: improve Gradle compatibility matrix

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.testing.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.testing.gradle.kts
@@ -6,6 +6,12 @@ plugins {
 tasks.withType<Test>().configureEach {
     buildParameters.testJdk?.let {
         javaLauncher.convention(javaToolchains.launcherFor(it))
+        // Pass JAVA_HOME for testJdkVersion to the test task, so it can spawn Gradle using the given Java home
+        jvmArgumentProviders.add(
+            CommandLineArgumentProvider {
+                listOf("-Dsigstore-java.test.JAVA_HOME=${javaLauncher.get().metadata.installationPath.asFile.absolutePath}")
+            }
+        )
     }
     if (project.hasProperty("skipOidc")) {
         systemProperty("sigstore-java.test.skipOidc", project.findProperty("skipOidc")!!)


### PR DESCRIPTION
Use Java home from testJdkVersion to launch test Gradle instances

See https://github.com/sigstore/sigstore-java/pull/1105#issuecomment-3517915305