### PR TITLE
docs: Update Maven Central badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/dev.sigstore/sigstore-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/dev.sigstore/sigstore-java)
+[![Maven Central](https://maven-badges.sml.io/maven-central/dev.sigstore/sigstore-java/badge.svg)](https://maven-badges.sml.io/maven-central/dev.sigstore/sigstore-java)
 [![javadoc](https://javadoc.io/badge2/dev.sigstore/sigstore-java/javadoc.svg)](https://javadoc.io/doc/dev.sigstore/sigstore-java)
 [![CI](https://github.com/sigstore/sigstore-java/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/sigstore/sigstore-java/actions/workflows/ci.yaml)
 


### PR DESCRIPTION
#### Summary

This change updates the Maven Central badge URL in the README, as the current URL is deprecated and will be unavailable in 2026 (see [here](https://github.com/softwaremill/maven-badges?tab=readme-ov-file#a-new-dns-address)).