### PR TITLE
Wrap json operations for checked exceptions

### DIFF
--- a/config/forbiddenApis.txt
+++ b/config/forbiddenApis.txt
@@ -1,2 +1,3 @@
 com.google.protobuf.util.JsonFormat#parser() @ Use dev.sigstore.json.ProtoJson#parser() instead
 dev.sigstore.http.HttpClients#newHttpTransport(dev.sigstore.http.HttpParams) @ Use dev.sigstore.http.HttpClients#newRequestFactory(...) instead
+com.google.gson.GsonBuilder @ Use dev.sigstore.json.GsonSupplier.GSON instead

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -22,7 +22,6 @@ import com.google.common.hash.Hashing;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import com.google.gson.JsonSyntaxException;
 import com.google.protobuf.ByteString;
 import dev.sigstore.bundle.Bundle;
 import dev.sigstore.bundle.Bundle.MessageSignature;
@@ -40,6 +39,7 @@ import dev.sigstore.fulcio.client.FulcioClientGrpc;
 import dev.sigstore.fulcio.client.FulcioVerificationException;
 import dev.sigstore.fulcio.client.FulcioVerifier;
 import dev.sigstore.fulcio.client.UnsupportedAlgorithmException;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.oidc.client.OidcClients;
 import dev.sigstore.oidc.client.OidcException;
 import dev.sigstore.oidc.client.OidcToken;
@@ -697,7 +697,7 @@ public class KeylessSigner implements AutoCloseable {
     InTotoPayload inTotoPayload;
     try {
       inTotoPayload = InTotoPayload.from(payload);
-    } catch (JsonSyntaxException jse) {
+    } catch (JsonParseException jse) {
       throw new IllegalArgumentException("Payload is not a valid in-toto statement");
     }
 

--- a/sigstore-java/src/main/java/dev/sigstore/dsse/InTotoPayload.java
+++ b/sigstore-java/src/main/java/dev/sigstore/dsse/InTotoPayload.java
@@ -19,6 +19,7 @@ import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.gson.JsonElement;
 import dev.sigstore.bundle.Bundle.DsseEnvelope;
+import dev.sigstore.json.JsonParseException;
 import java.util.List;
 import java.util.Map;
 import org.immutables.gson.Gson;
@@ -51,11 +52,11 @@ public interface InTotoPayload {
     Map<String, String> getDigest();
   }
 
-  static InTotoPayload from(String payload) {
+  static InTotoPayload from(String payload) throws JsonParseException {
     return GSON.get().fromJson(payload, InTotoPayload.class);
   }
 
-  static InTotoPayload from(DsseEnvelope dsseEnvelope) {
+  static InTotoPayload from(DsseEnvelope dsseEnvelope) throws JsonParseException {
     return from(dsseEnvelope.getPayloadAsString());
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/json/GsonChecked.java
+++ b/sigstore-java/src/main/java/dev/sigstore/json/GsonChecked.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.json;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import java.io.Reader;
+import java.lang.reflect.Type;
+
+/** A Gson wrapper that catches all runtime exceptions. */
+public final class GsonChecked {
+
+  Gson gson;
+
+  GsonChecked(Gson gson) {
+    this.gson = gson;
+  }
+
+  public <T> T fromJson(JsonElement element, Class<T> classOfT) throws JsonParseException {
+    try {
+      return gson.fromJson(element, classOfT);
+    } catch (RuntimeException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  public <T> T fromJson(String json, Class<T> classOfT) throws JsonParseException {
+    try {
+      return gson.fromJson(json, classOfT);
+    } catch (RuntimeException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  public <T> T fromJson(String json, Type typeOfT) throws JsonParseException {
+    try {
+      return gson.fromJson(json, typeOfT);
+    } catch (RuntimeException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  public <T> T fromJson(Reader reader, Class<T> classOfT) throws JsonParseException {
+    try {
+      return gson.fromJson(reader, classOfT);
+    } catch (RuntimeException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  public <T> String toJson(T src) {
+    return gson.toJson(src);
+  }
+
+  public <T> void toJson(T src, Appendable writer) {
+    gson.toJson(src, writer);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/json/GsonSupplier.java
+++ b/sigstore-java/src/main/java/dev/sigstore/json/GsonSupplier.java
@@ -17,6 +17,7 @@ package dev.sigstore.json;
 
 import com.google.gson.*;
 import dev.sigstore.dsse.GsonAdaptersInTotoPayload;
+import dev.sigstore.forbidden.SuppressForbidden;
 import dev.sigstore.rekor.client.GsonAdaptersRekorEntry;
 import dev.sigstore.rekor.client.GsonAdaptersRekorEntryBody;
 import dev.sigstore.tuf.model.*;
@@ -30,42 +31,44 @@ import java.util.function.Supplier;
  * requests between sigstore and this client -- and should probably be used for any api call to
  * sigstore that expects JSON.
  */
-public enum GsonSupplier implements Supplier<Gson> {
+@SuppressForbidden(reason = "GsonBuilder")
+public enum GsonSupplier implements Supplier<GsonChecked> {
   GSON;
 
   @SuppressWarnings("ImmutableEnumChecker")
-  private final Gson gson =
-      new GsonBuilder()
-          .registerTypeAdapter(byte[].class, new GsonByteArrayAdapter())
-          .registerTypeAdapter(
-              LocalDateTime.class,
-              (JsonDeserializer<LocalDateTime>)
-                  (json, type, jsonDeserializationContext) ->
-                      ZonedDateTime.parse(json.getAsJsonPrimitive().getAsString())
-                          .toLocalDateTime())
-          // Immutables generated GSON Adapters in alphabetical order
-          .registerTypeAdapterFactory(new GsonAdaptersDelegations())
-          .registerTypeAdapterFactory(new GsonAdaptersDelegationRole())
-          .registerTypeAdapterFactory(new GsonAdaptersHashes())
-          .registerTypeAdapterFactory(new GsonAdaptersKey())
-          .registerTypeAdapterFactory(new GsonAdaptersRekorEntry())
-          .registerTypeAdapterFactory(new GsonAdaptersRekorEntryBody())
-          .registerTypeAdapterFactory(new GsonAdaptersRoot())
-          .registerTypeAdapterFactory(new GsonAdaptersRootMeta())
-          .registerTypeAdapterFactory(new GsonAdaptersRootRole())
-          .registerTypeAdapterFactory(new GsonAdaptersSignature())
-          .registerTypeAdapterFactory(new GsonAdaptersSnapshot())
-          .registerTypeAdapterFactory(new GsonAdaptersSnapshotMeta())
-          .registerTypeAdapterFactory(new GsonAdaptersTargets())
-          .registerTypeAdapterFactory(new GsonAdaptersTargetMeta())
-          .registerTypeAdapterFactory(new GsonAdaptersTimestamp())
-          .registerTypeAdapterFactory(new GsonAdaptersTimestampMeta())
-          .registerTypeAdapterFactory(new GsonAdaptersInTotoPayload())
-          .disableHtmlEscaping()
-          .create();
+  private final GsonChecked gson =
+      new GsonChecked(
+          new GsonBuilder()
+              .registerTypeAdapter(byte[].class, new GsonByteArrayAdapter())
+              .registerTypeAdapter(
+                  LocalDateTime.class,
+                  (JsonDeserializer<LocalDateTime>)
+                      (json, type, jsonDeserializationContext) ->
+                          ZonedDateTime.parse(json.getAsJsonPrimitive().getAsString())
+                              .toLocalDateTime())
+              // Immutables generated GSON Adapters in alphabetical order
+              .registerTypeAdapterFactory(new GsonAdaptersDelegations())
+              .registerTypeAdapterFactory(new GsonAdaptersDelegationRole())
+              .registerTypeAdapterFactory(new GsonAdaptersHashes())
+              .registerTypeAdapterFactory(new GsonAdaptersKey())
+              .registerTypeAdapterFactory(new GsonAdaptersRekorEntry())
+              .registerTypeAdapterFactory(new GsonAdaptersRekorEntryBody())
+              .registerTypeAdapterFactory(new GsonAdaptersRoot())
+              .registerTypeAdapterFactory(new GsonAdaptersRootMeta())
+              .registerTypeAdapterFactory(new GsonAdaptersRootRole())
+              .registerTypeAdapterFactory(new GsonAdaptersSignature())
+              .registerTypeAdapterFactory(new GsonAdaptersSnapshot())
+              .registerTypeAdapterFactory(new GsonAdaptersSnapshotMeta())
+              .registerTypeAdapterFactory(new GsonAdaptersTargets())
+              .registerTypeAdapterFactory(new GsonAdaptersTargetMeta())
+              .registerTypeAdapterFactory(new GsonAdaptersTimestamp())
+              .registerTypeAdapterFactory(new GsonAdaptersTimestampMeta())
+              .registerTypeAdapterFactory(new GsonAdaptersInTotoPayload())
+              .disableHtmlEscaping()
+              .create());
 
   @Override
-  public Gson get() {
+  public GsonChecked get() {
     return gson;
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/json/JsonParseException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/json/JsonParseException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.json;
+
+public class JsonParseException extends Exception {
+  public JsonParseException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClient.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.rekor.client;
 
+import dev.sigstore.json.JsonParseException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -57,5 +58,5 @@ public interface RekorClient {
    */
   List<String> searchEntry(
       String email, String hash, String publicKeyFormat, String publicKeyContent)
-      throws IOException;
+      throws IOException, JsonParseException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClientHttp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClientHttp.java
@@ -25,6 +25,7 @@ import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.util.Preconditions;
 import dev.sigstore.http.HttpClients;
 import dev.sigstore.http.HttpParams;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.trustroot.Service;
 import java.io.IOException;
 import java.net.URI;
@@ -130,7 +131,7 @@ public class RekorClientHttp implements RekorClient {
   @Override
   public List<String> searchEntry(
       String email, String hash, String publicKeyFormat, String publicKeyContent)
-      throws IOException {
+      throws IOException, JsonParseException {
     URI rekorSearchEndpoint = uri.resolve(REKOR_INDEX_SEARCH_PATH);
 
     HashMap<String, Object> publicKeyParams = null;

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorEntry.java
@@ -18,8 +18,8 @@ package dev.sigstore.rekor.client;
 import static dev.sigstore.json.GsonSupplier.GSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.gson.JsonParseException;
 import com.google.protobuf.InvalidProtocolBufferException;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.json.ProtoJson;
 import dev.sigstore.proto.ProtoMutators;
 import dev.sigstore.proto.rekor.v1.TransparencyLogEntry;
@@ -128,7 +128,7 @@ public interface RekorEntry {
    * Returns a decoded {@link RekorEntryBody} of the log entry. Use {@link RekorTypes} to further
    * process.
    */
-  @Derived
+  @Lazy
   default RekorEntryBody getBodyDecoded() throws JsonParseException {
     return GSON.get()
         .fromJson(new String(Base64.getDecoder().decode(getBody()), UTF_8), RekorEntryBody.class);
@@ -178,7 +178,9 @@ public interface RekorEntry {
       TransparencyLogEntry.Builder builder = TransparencyLogEntry.newBuilder();
       ProtoJson.parser().ignoringUnknownFields().merge(json, builder);
       return ProtoMutators.toRekorEntry(builder.build());
-    } catch (InvalidProtocolBufferException | JsonParseException | NullPointerException e) {
+    } catch (InvalidProtocolBufferException
+        | com.google.gson.JsonParseException
+        | NullPointerException e) {
       throw new RekorParseException("Failed to parse Rekor response JSON", e);
     }
   }

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorResponse.java
@@ -18,7 +18,7 @@ package dev.sigstore.rekor.client;
 import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.common.reflect.TypeToken;
-import com.google.gson.JsonSyntaxException;
+import dev.sigstore.json.JsonParseException;
 import java.net.URI;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -60,10 +60,10 @@ public interface RekorResponse {
     Map<String, RekorEntry> entryMap;
     try {
       entryMap = GSON.get().fromJson(rawResponse, type);
-    } catch (JsonSyntaxException
-        | NullPointerException
+    } catch (NullPointerException
         | NumberFormatException
-        | StringIndexOutOfBoundsException ex) {
+        | StringIndexOutOfBoundsException
+        | JsonParseException ex) {
       throw new RekorParseException("Rekor entry json could not be parsed: " + rawResponse, ex);
     }
     if (entryMap == null) {

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorTypes.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorTypes.java
@@ -17,8 +17,8 @@ package dev.sigstore.rekor.client;
 
 import static dev.sigstore.json.GsonSupplier.GSON;
 
-import com.google.gson.JsonParseException;
 import com.google.protobuf.InvalidProtocolBufferException;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.json.ProtoJson;
 import dev.sigstore.proto.rekor.v2.DSSELogEntryV002;
 import dev.sigstore.proto.rekor.v2.HashedRekordLogEntryV002;
@@ -119,18 +119,22 @@ public class RekorTypes {
 
   private static void expect(RekorEntry entry, String expectedKind, String expectedApiVersion)
       throws RekorTypeException {
-    var kind = entry.getBodyDecoded().getKind();
-    var apiVersion = entry.getBodyDecoded().getApiVersion();
-    if (!(kind.equals(expectedKind) && apiVersion.equals(expectedApiVersion))) {
-      throw new RekorTypeException(
-          "Expecting type "
-              + expectedKind
-              + ":"
-              + expectedApiVersion
-              + ", but found "
-              + kind
-              + ":"
-              + apiVersion);
+    try {
+      var kind = entry.getBodyDecoded().getKind();
+      var apiVersion = entry.getBodyDecoded().getApiVersion();
+      if (!(kind.equals(expectedKind) && apiVersion.equals(expectedApiVersion))) {
+        throw new RekorTypeException(
+            "Expecting type "
+                + expectedKind
+                + ":"
+                + expectedApiVersion
+                + ", but found "
+                + kind
+                + ":"
+                + apiVersion);
+      }
+    } catch (JsonParseException jpe) {
+      throw new RekorTypeException("Could not parse type from entry", jpe);
     }
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/FileSystemTufStore.java
@@ -18,6 +18,7 @@ package dev.sigstore.tuf;
 import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.common.annotations.VisibleForTesting;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.*;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -97,7 +98,7 @@ public class FileSystemTufStore implements MetaStore, TargetStore {
 
   @Override
   public <T extends SignedTufMeta<?>> Optional<T> readMeta(String roleName, Class<T> tClass)
-      throws IOException {
+      throws IOException, JsonParseException {
     Path roleFile = repoBaseDir.resolve(roleName + ".json");
     if (!roleFile.toFile().exists()) {
       return Optional.empty();

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaFetcher.java
@@ -18,6 +18,7 @@ package dev.sigstore.tuf;
 import static dev.sigstore.json.GsonSupplier.GSON;
 
 import com.google.common.base.Preconditions;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.Root;
 import dev.sigstore.tuf.model.SignedTufMeta;
 import dev.sigstore.tuf.model.TufMeta;
@@ -45,19 +46,20 @@ public class MetaFetcher {
   }
 
   public Optional<MetaFetchResult<Root>> getRootAtVersion(int version)
-      throws IOException, FileExceedsMaxLengthException {
+      throws IOException, FileExceedsMaxLengthException, JsonParseException {
     String versionFileName = version + ".root.json";
     return getMeta(versionFileName, Root.class, null);
   }
 
   public <T extends SignedTufMeta<? extends TufMeta>> Optional<MetaFetchResult<T>> getMeta(
-      String role, Class<T> t) throws IOException, FileExceedsMaxLengthException {
+      String role, Class<T> t)
+      throws IOException, FileExceedsMaxLengthException, JsonParseException {
     return getMeta(getFileName(role, null), t, null);
   }
 
   public <T extends SignedTufMeta<? extends TufMeta>> Optional<MetaFetchResult<T>> getMeta(
       String role, int version, Class<T> t, Integer maxSize)
-      throws IOException, FileExceedsMaxLengthException {
+      throws IOException, FileExceedsMaxLengthException, JsonParseException {
     Preconditions.checkArgument(version > 0, "version should be positive, got: %s", version);
     return getMeta(getFileName(role, version), t, maxSize);
   }
@@ -70,7 +72,7 @@ public class MetaFetcher {
 
   <T extends SignedTufMeta<? extends TufMeta>> Optional<MetaFetchResult<T>> getMeta(
       String filename, Class<T> t, Integer maxSize)
-      throws IOException, FileExceedsMaxLengthException {
+      throws IOException, FileExceedsMaxLengthException, JsonParseException {
     byte[] roleBytes = fetcher.fetchResource(filename, maxSize == null ? MAX_META_BYTES : maxSize);
     if (roleBytes == null) {
       return Optional.empty();

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/MetaReader.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/MetaReader.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf;
 
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.SignedTufMeta;
 import dev.sigstore.tuf.model.TufMeta;
 import java.io.IOException;
@@ -33,5 +34,5 @@ public interface MetaReader {
    * @throws IOException if an error occurs reading from the backing store
    */
   <T extends SignedTufMeta<? extends TufMeta>> Optional<T> readMeta(
-      String roleName, Class<T> tClass) throws IOException;
+      String roleName, Class<T> tClass) throws IOException, JsonParseException;
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/PassthroughCacheMetaStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/PassthroughCacheMetaStore.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf;
 
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.SignedTufMeta;
 import dev.sigstore.tuf.model.TufMeta;
 import java.io.IOException;
@@ -44,7 +45,7 @@ public class PassthroughCacheMetaStore implements MetaReader, MetaStore {
   @Override
   @SuppressWarnings("unchecked")
   public <T extends SignedTufMeta<? extends TufMeta>> Optional<T> readMeta(
-      String roleName, Class<T> tClass) throws IOException {
+      String roleName, Class<T> tClass) throws IOException, JsonParseException {
     // check memory cache
     if (cache.containsKey(roleName)) {
       return Optional.of((T) cache.get(roleName));

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/SigstoreTufClient.java
@@ -18,6 +18,7 @@ package dev.sigstore.tuf;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import dev.sigstore.http.URIFormat;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.trustroot.SigstoreConfigurationException;
 import dev.sigstore.trustroot.SigstoreSigningConfig;
 import dev.sigstore.trustroot.SigstoreTrustedRoot;
@@ -152,7 +153,8 @@ public class SigstoreTufClient {
     } catch (IOException
         | NoSuchAlgorithmException
         | InvalidKeySpecException
-        | InvalidKeyException ex) {
+        | InvalidKeyException
+        | JsonParseException ex) {
       throw new SigstoreConfigurationException("TUF repo failed to update", ex);
     }
     lastUpdate = Instant.now();

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/TrustedMetaStore.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/TrustedMetaStore.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.tuf;
 
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.Root;
 import dev.sigstore.tuf.model.RootRole;
 import dev.sigstore.tuf.model.SignedTufMeta;
@@ -58,7 +59,7 @@ public class TrustedMetaStore {
    * @throws IllegalStateException if the data was never persisted and this function was called
    */
   <T extends SignedTufMeta<? extends TufMeta>> T getMeta(String roleName, Class<T> tClass)
-      throws IOException {
+      throws IOException, JsonParseException {
     return metaStore
         .readMeta(roleName, tClass)
         .orElseThrow(
@@ -73,11 +74,11 @@ public class TrustedMetaStore {
     metaStore.writeMeta(RootRole.ROOT, root);
   }
 
-  public Root getRoot() throws IOException {
+  public Root getRoot() throws IOException, JsonParseException {
     return getMeta(RootRole.ROOT, Root.class);
   }
 
-  public Optional<Root> findRoot() throws IOException {
+  public Optional<Root> findRoot() throws IOException, JsonParseException {
     return metaStore.readMeta(RootRole.ROOT, Root.class);
   }
 
@@ -85,11 +86,11 @@ public class TrustedMetaStore {
     metaStore.writeMeta(RootRole.TIMESTAMP, timestamp);
   }
 
-  public Timestamp getTimestamp() throws IOException {
+  public Timestamp getTimestamp() throws IOException, JsonParseException {
     return getMeta(RootRole.TIMESTAMP, Timestamp.class);
   }
 
-  public Optional<Timestamp> findTimestamp() throws IOException {
+  public Optional<Timestamp> findTimestamp() throws IOException, JsonParseException {
     return metaStore.readMeta(RootRole.TIMESTAMP, Timestamp.class);
   }
 
@@ -97,11 +98,11 @@ public class TrustedMetaStore {
     metaStore.writeMeta(RootRole.SNAPSHOT, snapshot);
   }
 
-  public Snapshot getSnapshot() throws IOException {
+  public Snapshot getSnapshot() throws IOException, JsonParseException {
     return getMeta(RootRole.SNAPSHOT, Snapshot.class);
   }
 
-  public Optional<Snapshot> findSnapshot() throws IOException {
+  public Optional<Snapshot> findSnapshot() throws IOException, JsonParseException {
     return metaStore.readMeta(RootRole.SNAPSHOT, Snapshot.class);
   }
 
@@ -109,11 +110,11 @@ public class TrustedMetaStore {
     metaStore.writeMeta(RootRole.TARGETS, targets);
   }
 
-  public Targets getTargets() throws IOException {
+  public Targets getTargets() throws IOException, JsonParseException {
     return getMeta(RootRole.TARGETS, Targets.class);
   }
 
-  public Optional<Targets> findTargets() throws IOException {
+  public Optional<Targets> findTargets() throws IOException, JsonParseException {
     return metaStore.readMeta(RootRole.TARGETS, Targets.class);
   }
 

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Root.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Root.java
@@ -16,9 +16,9 @@
 package dev.sigstore.tuf.model;
 
 import com.google.common.base.Preconditions;
+import dev.sigstore.json.JsonParseException;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Derived;
 
 /** Signed envelope of the Root metadata. */
 @Gson.TypeAdapters
@@ -26,13 +26,17 @@ import org.immutables.value.Value.Derived;
 public interface Root extends SignedTufMeta<RootMeta> {
   @Override
   @Gson.Ignore
-  @Derived
-  default RootMeta getSignedMeta() {
+  @Value.Lazy
+  default RootMeta getSignedMeta() throws JsonParseException {
     return getSignedMeta(RootMeta.class);
   }
 
   @Value.Check
   default void checkType() {
-    Preconditions.checkState(getSignedMeta().getType().equals("root"));
+    try {
+      Preconditions.checkState(getSignedMeta().getType().equals("root"));
+    } catch (JsonParseException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/SignedTufMeta.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/SignedTufMeta.java
@@ -17,11 +17,11 @@ package dev.sigstore.tuf.model;
 
 import com.google.gson.JsonElement;
 import dev.sigstore.json.GsonSupplier;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.json.canonicalizer.JsonCanonicalizer;
 import java.io.IOException;
 import java.util.List;
 import org.immutables.gson.Gson;
-import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Lazy;
 
 /**
@@ -34,12 +34,12 @@ public interface SignedTufMeta<T extends TufMeta> {
   List<Signature> getSignatures();
 
   /** The role metadata that has been signed. */
-  T getSignedMeta();
+  T getSignedMeta() throws JsonParseException;
 
   /** An internal helper to translate raw signed json to a useable type. */
-  @Derived
+  @Lazy
   @Gson.Ignore
-  default T getSignedMeta(Class<T> type) {
+  default T getSignedMeta(Class<T> type) throws JsonParseException {
     return GsonSupplier.GSON.get().fromJson(getRawSignedMeta(), type);
   }
 

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Snapshot.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Snapshot.java
@@ -16,23 +16,27 @@
 package dev.sigstore.tuf.model;
 
 import com.google.common.base.Preconditions;
+import dev.sigstore.json.JsonParseException;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Derived;
 
 /** Signed envelope of the Snapshot metadata. */
 @Gson.TypeAdapters
 @Value.Immutable
 public interface Snapshot extends SignedTufMeta<SnapshotMeta> {
   @Override
-  @Derived
+  @Value.Lazy
   @Gson.Ignore
-  default SnapshotMeta getSignedMeta() {
+  default SnapshotMeta getSignedMeta() throws JsonParseException {
     return getSignedMeta(SnapshotMeta.class);
   }
 
   @Value.Check
   default void checkType() {
-    Preconditions.checkState(getSignedMeta().getType().equals("snapshot"));
+    try {
+      Preconditions.checkState(getSignedMeta().getType().equals("snapshot"));
+    } catch (JsonParseException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Targets.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Targets.java
@@ -16,23 +16,27 @@
 package dev.sigstore.tuf.model;
 
 import com.google.common.base.Preconditions;
+import dev.sigstore.json.JsonParseException;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Derived;
 
 /** Signed envelope of the Targets metadata. */
 @Gson.TypeAdapters
 @Value.Immutable
 public interface Targets extends SignedTufMeta<TargetMeta> {
   @Override
-  @Derived
+  @Value.Lazy
   @Gson.Ignore
-  default TargetMeta getSignedMeta() {
+  default TargetMeta getSignedMeta() throws JsonParseException {
     return getSignedMeta(TargetMeta.class);
   }
 
   @Value.Check
   default void checkType() {
-    Preconditions.checkState(getSignedMeta().getType().equals("targets"));
+    try {
+      Preconditions.checkState(getSignedMeta().getType().equals("targets"));
+    } catch (JsonParseException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/tuf/model/Timestamp.java
@@ -16,9 +16,9 @@
 package dev.sigstore.tuf.model;
 
 import com.google.common.base.Preconditions;
+import dev.sigstore.json.JsonParseException;
 import org.immutables.gson.Gson;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Derived;
 
 /** Signed envelope of the Timestamp metadata. */
 @Gson.TypeAdapters
@@ -26,14 +26,18 @@ import org.immutables.value.Value.Derived;
 public interface Timestamp extends SignedTufMeta<TimestampMeta> {
 
   @Override
-  @Derived
+  @Value.Lazy
   @Gson.Ignore
-  default TimestampMeta getSignedMeta() {
+  default TimestampMeta getSignedMeta() throws JsonParseException {
     return getSignedMeta(TimestampMeta.class);
   }
 
   @Value.Check
   default void checkType() {
-    Preconditions.checkState(getSignedMeta().getType().equals("timestamp"));
+    try {
+      Preconditions.checkState(getSignedMeta().getType().equals("timestamp"));
+    } catch (JsonParseException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -18,6 +18,7 @@ package dev.sigstore;
 import com.google.common.hash.Hashing;
 import dev.sigstore.bundle.Bundle;
 import dev.sigstore.dsse.InTotoPayload;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.testkit.annotations.DisabledIfSkipStaging;
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists;
 import dev.sigstore.testkit.annotations.OidcProviderType;
@@ -119,7 +120,8 @@ public class KeylessTest {
     checkBundleSerialization(result);
   }
 
-  private void verifySigningResult(List<Bundle> results, boolean enableRekorV2) throws IOException {
+  private void verifySigningResult(List<Bundle> results, boolean enableRekorV2)
+      throws IOException, JsonParseException {
 
     Assertions.assertEquals(artifactDigests.size(), results.size());
 

--- a/sigstore-java/src/test/java/dev/sigstore/json/GsonSupplierTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/json/GsonSupplierTest.java
@@ -17,14 +17,12 @@ package dev.sigstore.json;
 
 import static dev.sigstore.json.GsonSupplier.GSON;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class GsonSupplierTest {
-  private final Gson gson = GSON.get();
+  private final GsonChecked gson = GSON.get();
 
   @Test
   public void testWrite() {
@@ -32,7 +30,7 @@ public class GsonSupplierTest {
   }
 
   @Test
-  public void testRead() {
+  public void testRead() throws Exception {
     Assertions.assertArrayEquals(
         "abcd".getBytes(StandardCharsets.UTF_8), gson.fromJson("\"YWJjZA==\"", byte[].class));
     Assertions.assertArrayEquals(new byte[] {}, gson.fromJson("\"\"", byte[].class));

--- a/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientHttpTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/rekor/client/RekorClientHttpTest.java
@@ -88,7 +88,7 @@ public class RekorClientHttpTest {
   }
 
   @Test
-  public void searchEntries_nullParams() throws IOException {
+  public void searchEntries_nullParams() throws Exception {
     assertEquals(ImmutableList.of(), client.searchEntry(null, null, null, null));
   }
 
@@ -129,7 +129,7 @@ public class RekorClientHttpTest {
   }
 
   @Test
-  public void searchEntries_zeroResults() throws IOException {
+  public void searchEntries_zeroResults() throws Exception {
     assertTrue(
         client
             .searchEntry(

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/FileSystemTufStoreTest.java
@@ -30,20 +30,20 @@ class FileSystemTufStoreTest {
   public static final String REPO = "synthetic/test-template";
 
   @Test
-  void newFileSystemStore_empty(@TempDir Path repoBase) throws IOException {
+  void newFileSystemStore_empty(@TempDir Path repoBase) throws Exception {
     FileSystemTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertFalse(tufStore.readMeta(RootRole.ROOT, Root.class).isPresent());
   }
 
   @Test
-  void newFileSystemStore_hasRepo(@TempDir Path repoBase) throws IOException {
+  void newFileSystemStore_hasRepo(@TempDir Path repoBase) throws Exception {
     TestResources.setupRepoFiles(REPO, repoBase, "root.json");
     FileSystemTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertTrue(tufStore.readMeta(RootRole.ROOT, Root.class).isPresent());
   }
 
   @Test
-  void writeMeta(@TempDir Path repoBase) throws IOException {
+  void writeMeta(@TempDir Path repoBase) throws Exception {
     FileSystemTufStore tufStore = FileSystemTufStore.newFileSystemStore(repoBase);
     assertFalse(repoBase.resolve("root.json").toFile().exists());
     tufStore.writeMeta(

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/PassthroughCacheMetaStoreTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/PassthroughCacheMetaStoreTest.java
@@ -40,7 +40,7 @@ class PassthroughCacheMetaStoreTest {
   private static Timestamp timestamp;
 
   @BeforeAll
-  public static void readAllMeta() throws IOException {
+  public static void readAllMeta() throws Exception {
     Path timestampResource =
         Path.of(
             Resources.getResource("dev/sigstore/tuf/synthetic/test/repository/timestamp.json")

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/UpdaterTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import com.google.gson.JsonSyntaxException;
 import dev.sigstore.http.URIFormat;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.testkit.tuf.TestResources;
 import dev.sigstore.tuf.encryption.Verifier;
 import dev.sigstore.tuf.encryption.Verifiers;
@@ -481,7 +481,7 @@ class UpdaterTest {
     var updater = createTimeStaticUpdater(localStorePath, UPDATER_SYNTHETIC_TRUSTED_ROOT);
     var ex =
         assertThrows(
-            JsonSyntaxException.class,
+            JsonParseException.class,
             updater::update,
             "targets.json data should be causing a gson error due to missing TargetData. If at some point we support nullable TargetData this test should be updated to expect TargetMetadataMissingException while calling downloadTargets().");
     MatcherAssert.assertThat(

--- a/sigstore-java/src/test/java/dev/sigstore/tuf/model/TestTufJsonLoading.java
+++ b/sigstore-java/src/test/java/dev/sigstore/tuf/model/TestTufJsonLoading.java
@@ -20,9 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.io.Resources;
-import com.google.gson.JsonSyntaxException;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.TargetMeta.TargetData;
-import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.time.ZonedDateTime;
@@ -34,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class TestTufJsonLoading {
 
   @Test
-  public void loadRootJson() throws IOException {
+  public void loadRootJson() throws Exception {
     Root trustRoot;
     try (Reader reader =
         Resources.asCharSource(
@@ -70,7 +69,7 @@ public class TestTufJsonLoading {
   }
 
   @Test
-  public void loadSnapshotJson() throws IOException {
+  public void loadSnapshotJson() throws Exception {
     Snapshot snapshot;
     try (Reader reader =
         Resources.asCharSource(
@@ -108,7 +107,7 @@ public class TestTufJsonLoading {
   }
 
   @Test
-  public void loadTargetsJson() throws IOException {
+  public void loadTargetsJson() throws Exception {
     Targets targets;
     try (Reader reader =
         Resources.asCharSource(
@@ -189,7 +188,7 @@ public class TestTufJsonLoading {
   public void loadTargetData_failNoHashes() {
     var error =
         Assertions.assertThrows(
-            JsonSyntaxException.class,
+            JsonParseException.class,
             () ->
                 GSON.get()
                     .fromJson(
@@ -197,6 +196,6 @@ public class TestTufJsonLoading {
                         TargetData.class));
     Assertions.assertEquals(
         "No hashes (sha256 or sha512) found for target data: TargetData{custom=Custom{sigstoreMeta=SigstoreMeta{status=Active, usage=CTFE}}, hashes=Hashes{}, length=177}",
-        error.getCause().getMessage());
+        error.getCause().getCause().getMessage());
   }
 }

--- a/sigstore-testkit/src/main/java/dev/sigstore/testkit/tuf/TestResources.java
+++ b/sigstore-testkit/src/main/java/dev/sigstore/testkit/tuf/TestResources.java
@@ -17,6 +17,7 @@ package dev.sigstore.testkit.tuf;
 
 import com.google.common.io.Resources;
 import dev.sigstore.json.GsonSupplier;
+import dev.sigstore.json.JsonParseException;
 import dev.sigstore.tuf.model.Root;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,7 +45,7 @@ public class TestResources {
     }
   }
 
-  public static Root loadRoot(Path rootPath) throws IOException {
+  public static Root loadRoot(Path rootPath) throws IOException, JsonParseException {
     return GsonSupplier.GSON.get().fromJson(Files.readString(rootPath), Root.class);
   }
 }


### PR DESCRIPTION
This is deal with other versions of this bug https://github.com/immutables/immutables/issues/1619. We probably don't want runtime json exception anyway.

It looks big, but it's mostly just handling this new checked exception