### PR TITLE
ref(deps): Migrate UpdaterTest from Jetty to MockWebServer

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
     testImplementation("no.nav.security:mock-oauth2-server:0.5.10")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("net.sourceforge.htmlunit:htmlunit:2.70.0")
-    testImplementation("org.eclipse.jetty:jetty-server:11.0.26")
 
     testImplementation("io.github.netmikey.logunit:logunit-core:2.0.0")
     testRuntimeOnly("io.github.netmikey.logunit:logunit-jul:2.0.0")


### PR DESCRIPTION
#### Summary

This change migrates the server infrastructure in `UpdaterTest` from Jetty to `MockWebServer`, which offers a simpler approach.