### PR TITLE
catch more exceptions to avoid parsing errors from crashing process

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioCertificateMatcher.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioCertificateMatcher.java
@@ -167,8 +167,8 @@ public abstract class FulcioCertificateMatcher implements CertificateMatcher {
             "Fulcio certificates SAN must be of type rfc822 or URI");
       }
       return (String) san.get(1);
-    } catch (CertificateParsingException cpe) {
-      throw new CertificateParsingException("Could not parse SAN from fulcio certificate", cpe);
+    } catch (CertificateParsingException | RuntimeException e) {
+      throw new CertificateParsingException("Could not parse SAN from fulcio certificate", e);
     }
   }
 


### PR DESCRIPTION
### Fix: Catch `RuntimeException` in `FulcioCertificateMatcher.extractSan`

#### Description
Fuzzing identified an uncaught exception where `sun.security.x509.X509CertImpl.getSubjectAlternativeNames()` can throw a `RuntimeException` (such as "name cannot be encoded") when processing malformed certificates (e.g., issues parsing `EDIPartyName`).

Previously, only `CertificateParsingException` was caught in `extractSan()`, allowing unexpected `RuntimeException` bubbles to escape.

This PR expands the catch clause to wrap any `RuntimeException` into a `CertificateParsingException` as well, matching existing behavior for parsing failures and making the certificate matching logic robust against crashing inputs.

This expansion also proactively guards against downstream indexing (`IndexOutOfBoundsException`) or typecasting (`ClassCastException`) failures when traversing the SAN results list.