### PR TITLE
Replace URI.resolve with URIFormat.appendPath

### DIFF
--- a/config/forbiddenApis.txt
+++ b/config/forbiddenApis.txt
@@ -1,3 +1,5 @@
 com.google.protobuf.util.JsonFormat#parser() @ Use dev.sigstore.json.ProtoJson#parser() instead
 dev.sigstore.http.HttpClients#newHttpTransport(dev.sigstore.http.HttpParams) @ Use dev.sigstore.http.HttpClients#newRequestFactory(...) instead
 com.google.gson.GsonBuilder @ Use dev.sigstore.json.GsonSupplier.GSON instead
+java.net.URI#resolve(java.lang.String) @ Use dev.sigstore.http.URIFormat#appendPath(java.net.URI, java.lang.String) instead
+java.net.URI#resolve(java.net.URI) @ Use dev.sigstore.http.URIFormat#appendPath(java.net.URI, java.lang.String) instead

--- a/sigstore-java/src/main/java/dev/sigstore/http/URIFormat.java
+++ b/sigstore-java/src/main/java/dev/sigstore/http/URIFormat.java
@@ -15,6 +15,7 @@
  */
 package dev.sigstore.http;
 
+import dev.sigstore.forbidden.SuppressForbidden;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -64,6 +65,7 @@ public final class URIFormat {
    * @param path the path segment to append (e.g., "users" or "/users").
    * @return a new URI with the path appended (e.g., "http://example.com/api/users").
    */
+  @SuppressForbidden(reason = "URI#resolve")
   public static URI appendPath(URI base, String path) {
     String relativePath = path.replaceAll("^/+", "");
 

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClientHttp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/client/RekorClientHttp.java
@@ -25,6 +25,7 @@ import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.util.Preconditions;
 import dev.sigstore.http.HttpClients;
 import dev.sigstore.http.HttpParams;
+import dev.sigstore.http.URIFormat;
 import dev.sigstore.json.JsonParseException;
 import dev.sigstore.trustroot.Service;
 import java.io.IOException;
@@ -79,7 +80,7 @@ public class RekorClientHttp implements RekorClient {
   @Override
   public RekorResponse putEntry(HashedRekordRequest hashedRekordRequest)
       throws IOException, RekorParseException {
-    URI rekorPutEndpoint = uri.resolve(REKOR_ENTRIES_PATH);
+    URI rekorPutEndpoint = URIFormat.appendPath(uri, REKOR_ENTRIES_PATH);
 
     HttpRequest req =
         HttpClients.newRequestFactory(httpParams)
@@ -100,7 +101,7 @@ public class RekorClientHttp implements RekorClient {
               resp.parseAsString()));
     }
 
-    URI rekorEntryUri = uri.resolve(resp.getHeaders().getLocation());
+    URI rekorEntryUri = URIFormat.appendPath(uri, resp.getHeaders().getLocation());
     String entry = resp.parseAsString();
     return RekorResponse.newRekorResponse(rekorEntryUri, entry);
   }
@@ -113,7 +114,7 @@ public class RekorClientHttp implements RekorClient {
 
   @Override
   public Optional<RekorEntry> getEntry(String UUID) throws IOException, RekorParseException {
-    URI getEntryURI = uri.resolve(REKOR_ENTRIES_PATH + "/" + UUID);
+    URI getEntryURI = URIFormat.appendPath(uri, REKOR_ENTRIES_PATH + "/" + UUID);
     HttpRequest req =
         HttpClients.newRequestFactory(httpParams).buildGetRequest(new GenericUrl(getEntryURI));
     req.getHeaders().set("Accept", "application/json");
@@ -132,7 +133,7 @@ public class RekorClientHttp implements RekorClient {
   public List<String> searchEntry(
       String email, String hash, String publicKeyFormat, String publicKeyContent)
       throws IOException, JsonParseException {
-    URI rekorSearchEndpoint = uri.resolve(REKOR_INDEX_SEARCH_PATH);
+    URI rekorSearchEndpoint = URIFormat.appendPath(uri, REKOR_INDEX_SEARCH_PATH);
 
     HashMap<String, Object> publicKeyParams = null;
     if (publicKeyContent != null) {

--- a/sigstore-java/src/main/java/dev/sigstore/rekor/v2/client/RekorV2ClientHttp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/rekor/v2/client/RekorV2ClientHttp.java
@@ -24,6 +24,7 @@ import com.google.protobuf.util.JsonFormat;
 import dev.sigstore.http.HttpClients;
 import dev.sigstore.http.HttpParams;
 import dev.sigstore.http.ImmutableHttpParams;
+import dev.sigstore.http.URIFormat;
 import dev.sigstore.proto.rekor.v2.CreateEntryRequest;
 import dev.sigstore.proto.rekor.v2.DSSERequestV002;
 import dev.sigstore.proto.rekor.v2.HashedRekordRequestV002;
@@ -88,7 +89,7 @@ public class RekorV2ClientHttp implements RekorV2Client {
   }
 
   private RekorEntry putEntry(CreateEntryRequest request) throws IOException, RekorParseException {
-    URI rekorPutEndpoint = uri.resolve(REKOR_ENTRIES_PATH);
+    URI rekorPutEndpoint = URIFormat.appendPath(uri, REKOR_ENTRIES_PATH);
 
     String jsonPayload = JsonFormat.printer().print(request);
 

--- a/sigstore-java/src/test/java/dev/sigstore/testing/FulcioWrapper.java
+++ b/sigstore-java/src/test/java/dev/sigstore/testing/FulcioWrapper.java
@@ -17,6 +17,7 @@ package dev.sigstore.testing;
 
 import com.google.gson.Gson;
 import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.http.URIFormat;
 import dev.sigstore.trustroot.Service;
 import java.io.IOException;
 import java.net.URI;
@@ -56,7 +57,10 @@ public class FulcioWrapper implements BeforeEachCallback, AfterEachCallback, Par
 
   public CertPath getTrustBundle() throws CertificateException, IOException, InterruptedException {
     HttpRequest req =
-        HttpRequest.newBuilder().uri(getURI().resolve("/api/v2/trustBundle")).GET().build();
+        HttpRequest.newBuilder()
+            .uri(URIFormat.appendPath(getURI(), "/api/v2/trustBundle"))
+            .GET()
+            .build();
     HttpResponse<String> response = HttpClient.newHttpClient().send(req, BodyHandlers.ofString());
 
     TrustBundle tb = new Gson().fromJson(response.body(), TrustBundle.class);


### PR DESCRIPTION
Closes #1005

#### Summary

This change replaces all calls to `URI.resolve` with a call to the custom URI handler `URIFormat.appendPath`, to predictably handle trailing slashes in base URLs.