### PR TITLE
Replace URI.resolve with URIFormat.appendPath

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioClientHttp.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/FulcioClientHttp.java
@@ -30,6 +30,7 @@ import dev.sigstore.fulcio.v2.PublicKeyRequest;
 import dev.sigstore.fulcio.v2.SigningCertificate;
 import dev.sigstore.http.HttpClients;
 import dev.sigstore.http.HttpParams;
+import dev.sigstore.http.URIFormat;
 import dev.sigstore.json.ProtoJson;
 import dev.sigstore.trustroot.Service;
 import java.io.IOException;
@@ -87,7 +88,7 @@ public class FulcioClientHttp implements FulcioClient {
    */
   @Override
   public CertPath signingCertificate(CertificateRequest request) throws CertificateException {
-    URI endpoint = uri.resolve(FULCIO_SIGNING_CERT_PATH);
+    URI endpoint = URIFormat.appendPath(uri, FULCIO_SIGNING_CERT_PATH);
 
     String pemEncodedPublicKey =
         "-----BEGIN PUBLIC KEY-----\n"


### PR DESCRIPTION
#### Summary

This change is a follow-up to #1182 to replace one instance of `URI.resolve` with `URIFormat.appendPath`.

The instance was introduced in a conflicting merge shortly after the banning of `URI.resolve`.