### PR TITLE
Prioritize email over subject for SAN from OIDC token string

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -54,7 +54,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Run Conformance Tests (production)
-        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+        uses: sigstore/sigstore-conformance@4d66ba3cb0c9c95f705c757c0f5e226d3f4d5151 # v0.0.27
         with:
           entrypoint: ${{ github.workspace }}/sigstore-cli/sigstore-cli-server
           environment: production
@@ -66,7 +66,7 @@ jobs:
             test_sign_verify_dsse
 
       - name: Run Conformance Tests (staging)
-        uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+        uses: sigstore/sigstore-conformance@4d66ba3cb0c9c95f705c757c0f5e226d3f4d5151 # v0.0.27
         with:
           entrypoint: ${{ github.workspace }}/sigstore-cli/sigstore-cli-server
           environment: staging

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/TokenStringOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/TokenStringOidcClient.java
@@ -55,10 +55,26 @@ public class TokenStringOidcClient implements OidcClient {
     try {
       var idToken = idTokenProvider.getTokenString();
       var jws = JsonWebSignature.parse(new GsonFactory(), idToken);
+      String email = (String) jws.getPayload().get("email");
+      String san;
+      if (email != null) {
+        Boolean emailVerified = (Boolean) jws.getPayload().get("email_verified");
+        if (Boolean.FALSE.equals(emailVerified)) {
+          throw new OidcException(
+              String.format(
+                  java.util.Locale.ROOT,
+                  "identity provider '%s' reports email address '%s' has not been verified",
+                  jws.getPayload().getIssuer(),
+                  email));
+        }
+        san = email;
+      } else {
+        san = jws.getPayload().getSubject();
+      }
       return ImmutableOidcToken.builder()
           .idToken(idToken)
           .issuer(jws.getPayload().getIssuer())
-          .subjectAlternativeName(jws.getPayload().getSubject())
+          .subjectAlternativeName(san)
           .build();
     } catch (IOException e) {
       throw new OidcException("Failed to parse JWT", e);


### PR DESCRIPTION
#### Summary

This change updates the `TokenStringOidcClient` to prioritize the `email` claim in an OIDC token string over the `subject` for obtaining the SAN, as the former is used by the Sigstore conformance testing OIDC token to provide the SAN.

This change also updates the `Conformance Tests` workflow to use the latest version of `sigstore/sigstore-conformance`, [v0.0.27](https://github.com/sigstore/sigstore-conformance/releases/tag/v0.0.27), which more reliably provides a valid identity token.