### PR TITLE
ci: declare contents:read on gradle-wrapper-validation workflow

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yaml
+++ b/.github/workflows/gradle-wrapper-validation.yaml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block. The job here only checks out the repository and runs its tests / validation; no GitHub API call beyond the initial checkout is needed.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain compromise) is the canonical motivation: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Per-workflow caps bound that runtime authority irrespective of repo or org default, give drift protection if the default ever widens, and register with OpenSSF Scorecard's Token-Permissions check (which only credits explicit per-workflow declarations).

YAML validated locally with `yaml.safe_load`.
