### PR TITLE
ci: declare contents: read permissions on cifuzz workflow

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -1,5 +1,9 @@
 name: CIFuzz
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a top-level `permissions:` block declaring `contents: read` on `.github/workflows/cifuzz.yaml`.

The CIFuzz fuzz-testing workflow runs on pull requests and pushes to perform fuzz coverage; it does not push commits, create releases, comment on PRs, or call any GitHub write API. `contents: read` is therefore the minimum sufficient token scope.

I previously opened a related PR (#1188) for the gradle-wrapper-validation workflow in this repo. This is the same shape applied to the fuzz workflow, kept as a separate PR so each can be reviewed in isolation.

A short list of reasons this is cheap-but-worth-doing:
- The OpenSSF Scorecard `Token-Permissions` check flags any workflow that does not declare explicit perms.
- After the tj-actions/changed-files supply-chain incident (CVE-2025-30066, March 2025), explicit minimum permissions are one of the cheaper defenses against compromised third-party actions.
- GitHub's own [hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) recommends this pattern.

Validated locally with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cifuzz.yaml'))"`. No other edits.
