### PR TITLE
Make algorithm registry more central to system

### DIFF
--- a/sigstore-java/src/main/java/dev/sigstore/AlgorithmRegistry.java
+++ b/sigstore-java/src/main/java/dev/sigstore/AlgorithmRegistry.java
@@ -15,11 +15,55 @@
  */
 package dev.sigstore;
 
-import static com.google.common.hash.Hashing.*;
+import static com.google.common.hash.Hashing.sha256;
 
 import com.google.common.hash.HashFunction;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
 
 public class AlgorithmRegistry {
+
+  /**
+   * Determine the signing algorithm based on the public key.
+   *
+   * @param publicKey the public key
+   * @return the signing algorithm
+   * @throws UnsupportedAlgorithmException if the key algorithm or curve is not supported
+   * @throws IllegalStateException if the public key cannot be converted into a known type
+   */
+  public static SigningAlgorithm getSigningAlgorithm(PublicKey publicKey)
+      throws UnsupportedAlgorithmException {
+    String algorithm = publicKey.getAlgorithm();
+    if ("RSA".equals(algorithm)) {
+      if (publicKey instanceof RSAPublicKey) {
+        var rsaKey = (RSAPublicKey) publicKey;
+        int bitLength = rsaKey.getModulus().bitLength();
+        if (bitLength == 2048) {
+          return SigningAlgorithm.PKIX_RSA_PKCS1V15_2048_SHA256;
+        } else if (bitLength == 3072) {
+          return SigningAlgorithm.PKIX_RSA_PKCS1V15_3072_SHA256;
+        } else if (bitLength == 4096) {
+          return SigningAlgorithm.PKIX_RSA_PKCS1V15_4096_SHA256;
+        }
+        throw new UnsupportedAlgorithmException("Unsupported RSA bit length: " + bitLength);
+      }
+      throw new IllegalStateException("RSA key must be an instance of RSAPublicKey");
+    }
+    if ("EC".equals(algorithm) || "ECDSA".equals(algorithm)) {
+      if (publicKey instanceof ECPublicKey) {
+        var ecKey = (ECPublicKey) publicKey;
+        int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+        if (fieldSize == 256) {
+          return SigningAlgorithm.PKIX_ECDSA_P256_SHA_256;
+        }
+        throw new UnsupportedAlgorithmException("Unsupported EC field size: " + fieldSize);
+      }
+      throw new IllegalStateException("EC/ECDSA key must be an instance of ECPublicKey");
+    }
+    throw new UnsupportedAlgorithmException("Unsupported key algorithm: " + algorithm);
+  }
+
   public enum SigningAlgorithm {
     PKIX_RSA_PKCS1V15_2048_SHA256(HashAlgorithm.SHA2_256),
     PKIX_RSA_PKCS1V15_3072_SHA256(HashAlgorithm.SHA2_256),
@@ -36,7 +80,7 @@ public class AlgorithmRegistry {
       this.hashAlgorithm = hashAlgorithm;
     }
 
-    public HashAlgorithm getHashing() {
+    public HashAlgorithm getHashAlgorithm() {
       return hashAlgorithm;
     }
   }

--- a/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
+++ b/sigstore-java/src/main/java/dev/sigstore/KeylessSigner.java
@@ -38,7 +38,6 @@ import dev.sigstore.fulcio.client.FulcioClient;
 import dev.sigstore.fulcio.client.FulcioClientGrpc;
 import dev.sigstore.fulcio.client.FulcioVerificationException;
 import dev.sigstore.fulcio.client.FulcioVerifier;
-import dev.sigstore.fulcio.client.UnsupportedAlgorithmException;
 import dev.sigstore.json.JsonParseException;
 import dev.sigstore.oidc.client.OidcClients;
 import dev.sigstore.oidc.client.OidcException;
@@ -337,7 +336,7 @@ public class KeylessSigner implements AutoCloseable {
         oidcClients = OidcClients.from(oidcService.get());
       }
 
-      if (!signingAlgorithm.getHashing().equals(AlgorithmRegistry.HashAlgorithm.SHA2_256)) {
+      if (!signingAlgorithm.getHashAlgorithm().equals(AlgorithmRegistry.HashAlgorithm.SHA2_256)) {
         throw new SigstoreConfigurationException("Signing algorithm must use sha256");
       }
 
@@ -402,7 +401,7 @@ public class KeylessSigner implements AutoCloseable {
     }
 
     for (var digest : artifactDigests) {
-      if (signingAlgorithm.getHashing().getLength() != digest.length) {
+      if (signingAlgorithm.getHashAlgorithm().getLength() != digest.length) {
         throw new KeylessSignerException(
             "Invalid digest length: "
                 + digest.length
@@ -457,7 +456,8 @@ public class KeylessSigner implements AutoCloseable {
           ImmutableBundle.builder()
               .certPath(signingCert)
               .messageSignature(
-                  MessageSignature.of(signingAlgorithm.getHashing(), artifactDigest, signature));
+                  MessageSignature.of(
+                      signingAlgorithm.getHashAlgorithm(), artifactDigest, signature));
 
       if (rekorV2Client != null) { // Using Rekor v2 and a TSA
         Preconditions.checkNotNull(
@@ -656,7 +656,9 @@ public class KeylessSigner implements AutoCloseable {
       var artifactByteSource = com.google.common.io.Files.asByteSource(artifact.toFile());
       try {
         digests.add(
-            artifactByteSource.hash(signingAlgorithm.getHashing().getHashFunction()).asBytes());
+            artifactByteSource
+                .hash(signingAlgorithm.getHashAlgorithm().getHashFunction())
+                .asBytes());
       } catch (IOException ex) {
         throw new KeylessSignerException("Failed to hash artifact " + artifact);
       }

--- a/sigstore-java/src/main/java/dev/sigstore/UnsupportedAlgorithmException.java
+++ b/sigstore-java/src/main/java/dev/sigstore/UnsupportedAlgorithmException.java
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package dev.sigstore.fulcio.client;
-
-import java.util.Arrays;
-import java.util.Set;
+package dev.sigstore;
 
 public class UnsupportedAlgorithmException extends Exception {
-  public UnsupportedAlgorithmException(Set<String> allowedAlgorithms, String algorithm) {
-    super(
-        algorithm
-            + " is not from supported list of "
-            + Arrays.toString(allowedAlgorithms.toArray()));
+  public UnsupportedAlgorithmException(String message) {
+    super(message);
+  }
+
+  public UnsupportedAlgorithmException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/sigstore-java/src/main/java/dev/sigstore/fulcio/client/CertificateRequest.java
+++ b/sigstore-java/src/main/java/dev/sigstore/fulcio/client/CertificateRequest.java
@@ -15,17 +15,15 @@
  */
 package dev.sigstore.fulcio.client;
 
-import com.google.common.collect.ImmutableMap;
+import dev.sigstore.AlgorithmRegistry;
+import dev.sigstore.UnsupportedAlgorithmException;
 import dev.sigstore.fulcio.v2.PublicKeyAlgorithm;
+import dev.sigstore.proto.ProtoMutators;
 import java.security.PublicKey;
-import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface CertificateRequest {
-  Map<String, PublicKeyAlgorithm> SUPPORTED_ALGORITHMS =
-      ImmutableMap.of("EC", PublicKeyAlgorithm.ECDSA, "RSA", PublicKeyAlgorithm.RSA_PSS);
-
   PublicKey getPublicKey();
 
   PublicKeyAlgorithm getPublicKeyAlgorithm();
@@ -37,23 +35,19 @@ public interface CertificateRequest {
   /**
    * Create a certificate request
    *
-   * @param publicKey An ECDSA public key
+   * @param publicKey A public key to verify {@code proofOfPossession}
    * @param idToken An oidc token obtained from an oauth provider
    * @param proofOfPossession The subject or email address from {@code idToken}, signed by the
    *     private key counterpart of {@code publicKey} in asn1 notation
-   * @throws UnsupportedAlgorithmException if key type is not in {@link
-   *     CertificateRequest#SUPPORTED_ALGORITHMS}
+   * @throws UnsupportedAlgorithmException if key type is not in {@link AlgorithmRegistry}
    */
   static CertificateRequest newCertificateRequest(
       PublicKey publicKey, String idToken, byte[] proofOfPossession)
       throws UnsupportedAlgorithmException {
-    if (!SUPPORTED_ALGORITHMS.containsKey(publicKey.getAlgorithm())) {
-      throw new UnsupportedAlgorithmException(
-          SUPPORTED_ALGORITHMS.keySet(), publicKey.getAlgorithm());
-    }
+    var signingAlgorithm = AlgorithmRegistry.getSigningAlgorithm(publicKey);
     return ImmutableCertificateRequest.builder()
         .publicKey(publicKey)
-        .publicKeyAlgorithm(SUPPORTED_ALGORITHMS.get(publicKey.getAlgorithm()))
+        .publicKeyAlgorithm(ProtoMutators.toPublicKeyAlgorithm(signingAlgorithm))
         .idToken(idToken)
         .proofOfPossession(proofOfPossession)
         .build();

--- a/sigstore-java/src/main/java/dev/sigstore/proto/ProtoMutators.java
+++ b/sigstore-java/src/main/java/dev/sigstore/proto/ProtoMutators.java
@@ -21,6 +21,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
 import dev.sigstore.AlgorithmRegistry;
 import dev.sigstore.encryption.certificates.Certificates;
+import dev.sigstore.fulcio.v2.PublicKeyAlgorithm;
 import dev.sigstore.proto.common.v1.HashAlgorithm;
 import dev.sigstore.proto.common.v1.PublicKeyDetails;
 import dev.sigstore.proto.common.v1.X509Certificate;
@@ -82,6 +83,19 @@ public class ProtoMutators {
         return PublicKeyDetails.PKIX_RSA_PKCS1V15_4096_SHA256;
       case PKIX_ECDSA_P256_SHA_256:
         return PublicKeyDetails.PKIX_ECDSA_P256_SHA_256;
+    }
+    throw new IllegalStateException("Unknown algorithm: " + algorithm);
+  }
+
+  public static PublicKeyAlgorithm toPublicKeyAlgorithm(
+      AlgorithmRegistry.SigningAlgorithm algorithm) {
+    switch (algorithm) {
+      case PKIX_RSA_PKCS1V15_2048_SHA256:
+      case PKIX_RSA_PKCS1V15_3072_SHA256:
+      case PKIX_RSA_PKCS1V15_4096_SHA256:
+        return PublicKeyAlgorithm.RSA_PSS;
+      case PKIX_ECDSA_P256_SHA_256:
+        return PublicKeyAlgorithm.ECDSA;
     }
     throw new IllegalStateException("Unknown algorithm: " + algorithm);
   }

--- a/sigstore-java/src/test/java/dev/sigstore/AlgorithmRegistryTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/AlgorithmRegistryTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import org.junit.jupiter.api.Test;
+
+public class AlgorithmRegistryTest {
+
+  @Test
+  public void testGetHashAlgorithm_Unsupported() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("DSA");
+    keyPairGen.initialize(2048);
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertThrows(
+        UnsupportedAlgorithmException.class,
+        () -> AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_RSA_2048() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("RSA");
+    keyPairGen.initialize(2048);
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertEquals(
+        AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_2048_SHA256,
+        AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_RSA_3072() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("RSA");
+    keyPairGen.initialize(3072);
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertEquals(
+        AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_3072_SHA256,
+        AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_RSA_4096() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("RSA");
+    keyPairGen.initialize(4096);
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertEquals(
+        AlgorithmRegistry.SigningAlgorithm.PKIX_RSA_PKCS1V15_4096_SHA256,
+        AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_EC_P256() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("EC");
+    keyPairGen.initialize(new ECGenParameterSpec("secp256r1"));
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertEquals(
+        AlgorithmRegistry.SigningAlgorithm.PKIX_ECDSA_P256_SHA_256,
+        AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_RSA_UnsupportedLength() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("RSA");
+    keyPairGen.initialize(1024);
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertThrows(
+        UnsupportedAlgorithmException.class,
+        () -> AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_RSA_NotRsaPublicKey() {
+    PublicKey mockRsaKey =
+        new PublicKey() {
+          @Override
+          public String getAlgorithm() {
+            return "RSA";
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+    assertThrows(
+        IllegalStateException.class, () -> AlgorithmRegistry.getSigningAlgorithm(mockRsaKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_EC_UnsupportedSize() throws Exception {
+    var keyPairGen = KeyPairGenerator.getInstance("EC");
+    keyPairGen.initialize(new ECGenParameterSpec("secp384r1"));
+    var publicKey = keyPairGen.generateKeyPair().getPublic();
+    assertThrows(
+        UnsupportedAlgorithmException.class,
+        () -> AlgorithmRegistry.getSigningAlgorithm(publicKey));
+  }
+
+  @Test
+  public void testGetHashAlgorithm_EC_NotEcPublicKey() {
+    PublicKey mockEcKey =
+        new PublicKey() {
+          @Override
+          public String getAlgorithm() {
+            return "EC";
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+    assertThrows(
+        IllegalStateException.class, () -> AlgorithmRegistry.getSigningAlgorithm(mockEcKey));
+  }
+}


### PR DESCRIPTION
This is more setup for using any hash algorithm in the system. But currently still limit to sha256.

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
