### PR TITLE
Add SIGSTORE_JAVA_ID_TOKEN for passing id token

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -56,9 +56,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-dev
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-    permissions:
-      id-token: write
-
     steps:
     - name: Enable long paths in Git
       if: runner.os == 'Windows'

--- a/examples/hello-world/test.sh
+++ b/examples/hello-world/test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -Eeo pipefail
-export MAVEN_GPG_KEY=$(cat ../pgp/private.key)
+MAVEN_GPG_KEY=$(cat ../pgp/private.key)
+export MAVEN_GPG_KEY
 export MAVEN_GPG_PASSPHRASE=pass123
 export ORG_GRADLE_PROJECT_signingKey=$MAVEN_GPG_KEY
 export ORG_GRADLE_PROJECT_signingPassword=$MAVEN_GPG_PASSPHRASE
+SIGSTORE_JAVA_ID_TOKEN=$(curl -f https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt)
+export SIGSTORE_JAVA_ID_TOKEN
 set -x
 # gradle
 ./gradlew clean publishMavenPublicationToExamplesRepository --stacktrace $@

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/EnvTokenProvider.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/EnvTokenProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+import java.util.Map;
+
+public class EnvTokenProvider implements TokenStringOidcClient.TokenStringProvider {
+  static final String ENV_VAR_NAME = "SIGSTORE_JAVA_ID_TOKEN";
+
+  static EnvTokenProvider of() {
+    return new EnvTokenProvider();
+  }
+
+  private EnvTokenProvider() {}
+
+  @Override
+  public boolean isEnabled(Map<String, String> env) {
+    return env.containsKey(ENV_VAR_NAME);
+  }
+
+  @Override
+  public String getTokenString(Map<String, String> env) throws Exception {
+    var token = env.get(ENV_VAR_NAME);
+    if (token == null) {
+      throw new IllegalStateException(ENV_VAR_NAME + " was not set");
+    }
+    return token;
+  }
+}

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/OidcClients.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/OidcClients.java
@@ -38,6 +38,7 @@ public class OidcClients {
    */
   public static OidcClients from(Service oidcService) {
     return of(
+        TokenStringOidcClient.from(EnvTokenProvider.of()),
         GithubActionsOidcClient.builder().build(),
         WebOidcClient.builder().setIssuer(oidcService).build());
   }

--- a/sigstore-java/src/main/java/dev/sigstore/oidc/client/TokenStringOidcClient.java
+++ b/sigstore-java/src/main/java/dev/sigstore/oidc/client/TokenStringOidcClient.java
@@ -42,18 +42,29 @@ public class TokenStringOidcClient implements OidcClient {
   }
 
   public static TokenStringOidcClient from(String token) {
-    return new TokenStringOidcClient(() -> token);
+    return new TokenStringOidcClient(
+        new TokenStringProvider() {
+          @Override
+          public String getTokenString(Map<String, String> env) throws Exception {
+            return token;
+          }
+
+          @Override
+          public boolean isEnabled(Map<String, String> env) {
+            return true;
+          }
+        });
   }
 
   @Override
   public boolean isEnabled(Map<String, String> env) {
-    return true;
+    return idTokenProvider.isEnabled(env);
   }
 
   @Override
   public OidcToken getIDToken(Map<String, String> env) throws OidcException {
     try {
-      var idToken = idTokenProvider.getTokenString();
+      var idToken = idTokenProvider.getTokenString(env);
       var jws = JsonWebSignature.parse(new GsonFactory(), idToken);
       String email = (String) jws.getPayload().get("email");
       String san;
@@ -83,8 +94,9 @@ public class TokenStringOidcClient implements OidcClient {
     }
   }
 
-  @FunctionalInterface
   public interface TokenStringProvider {
-    String getTokenString() throws Exception;
+    String getTokenString(Map<String, String> env) throws Exception;
+
+    boolean isEnabled(Map<String, String> env);
   }
 }

--- a/sigstore-java/src/test/java/dev/sigstore/oidc/client/EnvTokenProviderTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/oidc/client/EnvTokenProviderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Sigstore Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.sigstore.oidc.client;
+
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EnvTokenProviderTest {
+
+  @Test
+  public void isEnabled_true() {
+    var provider = EnvTokenProvider.of();
+    var env = Map.of(EnvTokenProvider.ENV_VAR_NAME, "some-token");
+    Assertions.assertTrue(provider.isEnabled(env));
+  }
+
+  @Test
+  public void isEnabled_false() {
+    var provider = EnvTokenProvider.of();
+    Assertions.assertFalse(provider.isEnabled(Map.of()));
+  }
+
+  @Test
+  public void getTokenString_present() throws Exception {
+    var provider = EnvTokenProvider.of();
+    var env = Map.of(EnvTokenProvider.ENV_VAR_NAME, "some-token");
+    Assertions.assertEquals("some-token", provider.getTokenString(env));
+  }
+
+  @Test
+  public void getTokenString_missing() {
+    var provider = EnvTokenProvider.of();
+    var env = Map.of("OTHER_ENV_VAR", "some-token");
+    var exception =
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> {
+              provider.getTokenString(env);
+            });
+    Assertions.assertEquals(EnvTokenProvider.ENV_VAR_NAME + " was not set", exception.getMessage());
+  }
+}

--- a/sigstore-testkit/src/main/java/dev/sigstore/testkit/oidc/ConformanceTestingTokenProvider.java
+++ b/sigstore-testkit/src/main/java/dev/sigstore/testkit/oidc/ConformanceTestingTokenProvider.java
@@ -22,6 +22,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * A token provider that will grab the "unsafe" token from sigstore github conformance testing. This
@@ -47,7 +48,12 @@ public class ConformanceTestingTokenProvider implements TokenStringOidcClient.To
   }
 
   @Override
-  public String getTokenString() throws Exception {
+  public boolean isEnabled(Map<String, String> env) {
+    return true;
+  }
+
+  @Override
+  public String getTokenString(Map<String, String> env) throws Exception {
     HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
     URI fileUri = new URI(tokenUrl);
     HttpRequest request =


### PR DESCRIPTION
- has highest priority in default configuarion for grabbing id token
- examples at dev version can use this

part of #1203 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
