### PR TITLE
build: replace deprecated Kotlin DSL property delegates

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.build-info.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.build-info.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     java
 }
 
-val generateBuildInfo by tasks.registering(BuildInfoTask::class) {
+val generateBuildInfo = tasks.register("generateBuildInfo", BuildInfoTask::class) {
     version.set(project.version.toString())
     genDir.set(project.layout.buildDirectory.dir("generated/buildinfo"))
 }

--- a/build-logic/jvm/src/main/kotlin/build-logic.dokka-javadoc.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.dokka-javadoc.gradle.kts
@@ -11,7 +11,7 @@ java {
     }
 }
 
-val dokkaJar by tasks.registering(Jar::class) {
+val dokkaJar = tasks.register("dokkaJar", Jar::class) {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Assembles a jar archive containing javadoc"
     from(tasks.dokkaGeneratePublicationJavadoc)

--- a/build-logic/publishing/src/main/kotlin/build-logic.depends-on-local-sigstore-java-repo.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.depends-on-local-sigstore-java-repo.gradle.kts
@@ -7,13 +7,13 @@ plugins {
     java
 }
 
-val sigstoreJavaRuntime by configurations.creating {
+val sigstoreJavaRuntime = configurations.create("sigstoreJavaRuntime") {
     description = "declares dependencies that will be useful for testing purposes"
     isCanBeConsumed = false
     isCanBeResolved = false
 }
 
-val sigstoreJavaTestClasspath by configurations.creating {
+val sigstoreJavaTestClasspath = configurations.create("sigstoreJavaTestClasspath") {
     description = "sigstore-java in local repository for testing purposes"
     isCanBeConsumed = false
     isCanBeResolved = true

--- a/build-logic/publishing/src/main/kotlin/build-logic.depends-on-local-sigstore-maven-plugin-repo.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.depends-on-local-sigstore-maven-plugin-repo.gradle.kts
@@ -7,13 +7,13 @@ plugins {
     java
 }
 
-val sigstoreMavenPluginRuntime by configurations.creating {
+val sigstoreMavenPluginRuntime = configurations.create("sigstoreMavenPluginRuntime") {
     description = "declares dependencies that will be useful for testing purposes"
     isCanBeConsumed = false
     isCanBeResolved = false
 }
 
-val sigstoreMavenPluginTestClasspath by configurations.creating {
+val sigstoreMavenPluginTestClasspath = configurations.create("sigstoreMavenPluginTestClasspath") {
     description = "sigstore-maven-plugin in local repository for testing purposes"
     isCanBeConsumed = false
     isCanBeResolved = true

--- a/build-logic/publishing/src/main/kotlin/build-logic.publish-to-tmp-maven-repo.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.publish-to-tmp-maven-repo.gradle.kts
@@ -1,11 +1,9 @@
-import org.gradle.kotlin.dsl.registering
-
 plugins {
     id("java-library")
     id("maven-publish")
 }
 
-val localRepoElements by configurations.creating {
+val localRepoElements = configurations.create("localRepoElements") {
     isCanBeConsumed = true
     isCanBeResolved = false
     description =
@@ -31,7 +29,7 @@ localRepoElements.outgoing.artifact(localRepoDir) {
     builtBy(tasks.named("publishAllPublicationsToTmp-mavenRepository"))
 }
 
-val cleanLocalRepository by tasks.registering(Delete::class) {
+val cleanLocalRepository = tasks.register("cleanLocalRepository", Delete::class) {
     description = "Clears local-maven-repo so timestamp-based snapshot artifacts do not consume space"
     delete(localRepoDir)
 }

--- a/build-logic/publishing/src/main/kotlin/build-logic.signing.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.signing.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    val signingKey = project.findProperty("signingKey") as String?
+    val signingPassword = project.findProperty("signingPassword") as String?
     useInMemoryPgpKeys(signingKey, signingPassword)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ allprojects {
     version = calculatedVersion
 }
 
-val parameters by tasks.registering {
+val parameters = tasks.register("parameters") {
     group = HelpTasksPlugin.HELP_GROUP
     description = "Displays build parameters (i.e. -P flags) that can be used to customize the build"
     dependsOn(gradle.includedBuild("build-logic").task(":build-parameters:parameters"))

--- a/examples/hello-world/build.gradle.kts
+++ b/examples/hello-world/build.gradle.kts
@@ -33,8 +33,8 @@ publishing {
 
 // PGP signing setup for the purposes of this example.
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    val signingKey = project.findProperty("signingKey") as String?
+    val signingPassword = project.findProperty("signingPassword") as String?
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications["maven"])
 }

--- a/sandbox/gradle-sign-file/build.gradle.kts
+++ b/sandbox/gradle-sign-file/build.gradle.kts
@@ -18,14 +18,14 @@ dependencies {
     // sigstoreClientClasspath("dev.sigstore:sigstore-java:0.1.0")
 }
 
-val hello by tasks.registering(WriteProperties::class) {
+val hello = tasks.register("hello", WriteProperties::class) {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Generates a sample $name.properties file to sign"
     destinationFile.set(layout.buildDirectory.file("props/$name.properties"))
     property("hello", "world")
 }
 
-val signFile by tasks.registering(SigstoreSignFilesTask::class) {
+val signFile = tasks.register("signFile", SigstoreSignFilesTask::class) {
     group = LifecycleBasePlugin.BUILD_GROUP
     description = "Signs file via Sigstore"
     signFile(hello.map { it.destinationFile.get().asFile })

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
@@ -30,7 +30,7 @@ gradle.sharedServices.registerIfAbsent(SigstoreSigningService.SERVICE_NAME, Sigs
     }
 }
 
-val sigstoreClient by configurations.creating {
+val sigstoreClient = configurations.create("sigstoreClient") {
     description = "Declares sigstore client dependencies"
     isCanBeResolved = false
     isCanBeConsumed = false
@@ -41,7 +41,7 @@ val sigstoreClient by configurations.creating {
     }
 }
 
-val sigstoreClientClasspath by configurations.creating {
+val sigstoreClientClasspath = configurations.create("sigstoreClientClasspath") {
     description = "Resolves Sigstore dependencies"
     isCanBeResolved = true
     isCanBeConsumed = false

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/PluginSmokeTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/PluginSmokeTest.kt
@@ -38,13 +38,13 @@ class PluginSmokeTest : BaseGradleTest() {
     fun `sign task dsl`() {
         project {
             apply(plugin = "dev.sigstore.sign-base")
-            val hello by tasks.registering(WriteProperties::class) {
+            val hello = tasks.register("hello", WriteProperties::class) {
                 destinationFile = layout.buildDirectory.file("props/$name.properties")
                 property("hello", "world")
             }
 
             // It should be eagerly created to access signOutput
-            val signFile by tasks.registering(SigstoreSignFilesTask::class) {
+            val signFile = tasks.register("signFile", SigstoreSignFilesTask::class) {
                 signFile(hello.map { it.destinationFile.asFile.get() })
             }
 


### PR DESCRIPTION
## Why

Gradle 9.6 deprecates all Kotlin DSL delegated-property extensions (`by creating`, `by registering`, `by project`), scheduled for removal in Gradle 10. Building with 9.6 prints deprecation warnings such as:

```
The 'val name by creating { }' property delegate syntax has been deprecated.
This is scheduled to be removed in Gradle 10. Use 'val element = create(name) { }' instead.
```

Fixes #1207.

## What

Replace the delegated-property syntax with the explicit container API and `findProperty` everywhere it appears:

| Before | After |
|--------|-------|
| `val x by configurations.creating { }` | `val x = configurations.create("x") { }` |
| `val x by tasks.registering(T::class) { }` | `val x = tasks.register("x", T::class) { }` |
| `val x: String? by project` | `val x = project.findProperty("x") as String?` |

Touched: the precompiled `dev.sigstore.sign-base` plugin (the file named in the issue), the `build-logic` convention scripts, the root `build.gradle.kts`, the `examples/hello-world` and `sandbox` builds, and the plugin smoke test. The redundant `import org.gradle.kotlin.dsl.registering` is dropped.

## How to verify

The new API is available on the current Gradle 8.14.3, so the change is backwards-compatible.

- `./gradlew help` (root), `cd sandbox && ./gradlew tasks`, `cd examples/hello-world && ./gradlew help` — all configure cleanly.
- `generateBuildInfo`, `dokkaJar`, and `cleanLocalRepository` still register and run.
- `./gradlew :sigstore-gradle:sigstore-gradle-sign-base-plugin:test --tests dev.sigstore.gradle.PluginSmokeTest` passes (2/2).
- On Gradle 9.6.0-rc-2, the recompiled plugin bytecode calls `ConfigurationContainer.create` rather than the deprecated `creating` delegate.

## Notes for reviewers

Building on Gradle 9.6 still emits one `by creating` warning, but it comes from the published `dev.sigstore:sigstore-gradle-sign-plugin:2.2.0` used to self-sign the build (`build-logic/publishing/build.gradle.kts`), confirmed via stack trace. It clears once that bootstrap dependency is bumped to a release containing this fix. The remaining `afterSuite`/`afterTest` warnings are pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)