### PR TITLE
Use the conformance token everywhere

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -17,9 +17,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-release
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-    permissions:
-      id-token: write
-
     steps:
     - name: Enable long paths in Git
       if: runner.os == 'Windows'

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -4,6 +4,8 @@ Simple sigstore signing examples
 
 These examples sign with sigstore (and PGP as required by Maven Central)
 
+In CI: These example use env `SIGSTORE_JAVA_ID_TOKEN` from test.sh to use a throwaway id token
+
 ## gradle
 
 ```

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/SigstoreSignTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/test/kotlin/dev/sigstore/gradle/SigstoreSignTest.kt
@@ -17,20 +17,19 @@
 package dev.sigstore.gradle
 
 import dev.sigstore.testkit.BaseGradleTest
-import dev.sigstore.testkit.TestedGradle
 import dev.sigstore.testkit.TestedGradleAndSigstoreJava
-import dev.sigstore.testkit.TestedSigstoreJava
-import dev.sigstore.testkit.annotations.EnabledIfOidcExists
+import dev.sigstore.testkit.oidc.ConformanceTestingToken
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.util.GradleVersion
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
-@EnabledIfOidcExists
 class SigstoreSignTest: BaseGradleTest() {
     @ParameterizedTest
     @MethodSource("gradleAndSigstoreJavaVersions")
     fun `sign file`(case: TestedGradleAndSigstoreJava) {
+        val oidcToken = ConformanceTestingToken.getToken()
+        gradleRunner.withEnvironment(mapOf("SIGSTORE_JAVA_ID_TOKEN" to oidcToken))
         val destLine =
             if (case.gradle.version < GradleVersion.version("8.0"))
                 """outputFile = file("helloProps.txt")"""

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/RemoveSigstoreAscTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/RemoveSigstoreAscTest.kt
@@ -19,14 +19,13 @@ package dev.sigstore.gradle
 import dev.sigstore.testkit.BaseGradleTest
 import dev.sigstore.testkit.TestedGradle
 import dev.sigstore.testkit.TestedGradleAndSigstoreJava
-import dev.sigstore.testkit.annotations.EnabledIfOidcExists
+import dev.sigstore.testkit.oidc.ConformanceTestingToken
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions
 import org.gradle.util.GradleVersion
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
-@EnabledIfOidcExists
 class RemoveSigstoreAscTest : BaseGradleTest() {
     companion object {
         @JvmStatic
@@ -102,6 +101,8 @@ class RemoveSigstoreAscTest : BaseGradleTest() {
     }
 
     private fun prepareBuildScripts(case: TestedGradleAndSigstoreJava) {
+        val oidcToken = ConformanceTestingToken.getToken()
+        gradleRunner.withEnvironment(mapOf("SIGSTORE_JAVA_ID_TOKEN" to oidcToken))
         writeBuildGradle(
             """
             plugins {

--- a/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/SigstorePublishSignTest.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-plugin/src/test/kotlin/dev/sigstore/gradle/SigstorePublishSignTest.kt
@@ -18,16 +18,17 @@ package dev.sigstore.gradle
 
 import dev.sigstore.testkit.BaseGradleTest
 import dev.sigstore.testkit.TestedGradleAndSigstoreJava
-import dev.sigstore.testkit.annotations.EnabledIfOidcExists
+import dev.sigstore.testkit.oidc.ConformanceTestingToken
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
-@EnabledIfOidcExists
 class SigstorePublishSignTest : BaseGradleTest() {
     @ParameterizedTest
     @MethodSource("gradleAndSigstoreJavaVersions")
     fun `sign file`(case: TestedGradleAndSigstoreJava) {
+        val oidcToken = ConformanceTestingToken.getToken()
+        gradleRunner.withEnvironment(mapOf("SIGSTORE_JAVA_ID_TOKEN" to oidcToken))
         writeBuildGradle(
             """
             plugins {

--- a/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
+++ b/sigstore-java/src/test/java/dev/sigstore/KeylessTest.java
@@ -19,9 +19,12 @@ import com.google.common.hash.Hashing;
 import dev.sigstore.bundle.Bundle;
 import dev.sigstore.dsse.InTotoPayload;
 import dev.sigstore.json.JsonParseException;
+import dev.sigstore.oidc.client.OidcClients;
+import dev.sigstore.oidc.client.TokenStringOidcClient;
 import dev.sigstore.testkit.annotations.DisabledIfSkipStaging;
 import dev.sigstore.testkit.annotations.EnabledIfOidcExists;
 import dev.sigstore.testkit.annotations.OidcProviderType;
+import dev.sigstore.testkit.oidc.ConformanceTestingToken;
 import dev.sigstore.trustroot.ImmutableSigstoreSigningConfig;
 import dev.sigstore.trustroot.Service;
 import dev.sigstore.tuf.SigstoreTufClient;
@@ -50,6 +53,9 @@ public class KeylessTest {
   public static List<byte[]> artifactDigests;
   public static String payload;
 
+  private static final OidcClients CONFORMANCE_TOKEN_CLIENT =
+      OidcClients.of(TokenStringOidcClient.from(ConformanceTestingToken.newProvider()));
+
   @BeforeAll
   public static void setupArtifact() throws IOException {
     artifactDigests = new ArrayList<>();
@@ -75,7 +81,7 @@ public class KeylessTest {
 
   @Test
   @EnabledIfOidcExists(provider = OidcProviderType.ANY)
-  public void sign_production() throws Exception {
+  public void sign_production_and_test_oidc() throws Exception {
     var signer = KeylessSigner.builder().sigstorePublicDefaults().build();
     var results = signer.sign(artifactDigests);
 
@@ -93,7 +99,6 @@ public class KeylessTest {
    * Should be merged into "sign_production" above when ready.
    */
   @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.ANY)
   public void sign_production_rekorV2() throws Exception {
     // TODO(#1033): Get Rekor v2 service from TUF signing config when in prod
     var prodTufClient = SigstoreTufClient.builder().usePublicGoodInstance().build();
@@ -107,6 +112,7 @@ public class KeylessTest {
     var signer =
         KeylessSigner.builder()
             .sigstorePublicDefaults()
+            .forceCredentialProviders(CONFORMANCE_TOKEN_CLIENT)
             .signingConfigProvider(() -> signingConfig)
             .enableRekorV2(true)
             .build();
@@ -123,11 +129,14 @@ public class KeylessTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  @EnabledIfOidcExists(provider = OidcProviderType.ANY)
   @DisabledIfSkipStaging
   public void sign_staging(boolean enableRekorV2) throws Exception {
     var signer =
-        KeylessSigner.builder().sigstoreStagingDefaults().enableRekorV2(enableRekorV2).build();
+        KeylessSigner.builder()
+            .sigstoreStagingDefaults()
+            .forceCredentialProviders(CONFORMANCE_TOKEN_CLIENT)
+            .enableRekorV2(enableRekorV2)
+            .build();
     var results = signer.sign(artifactDigests);
     verifySigningResult(results, enableRekorV2);
 
@@ -139,7 +148,6 @@ public class KeylessTest {
   }
 
   @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.ANY)
   public void attest_production() throws Exception {
     // TODO(#1033): Get Rekor v2 service from TUF signing config when in prod
     var prodTufClient = SigstoreTufClient.builder().usePublicGoodInstance().build();
@@ -153,6 +161,7 @@ public class KeylessTest {
     var signer =
         KeylessSigner.builder()
             .sigstorePublicDefaults()
+            .forceCredentialProviders(CONFORMANCE_TOKEN_CLIENT)
             .signingConfigProvider(() -> signingConfig)
             .enableRekorV2(true)
             .build();
@@ -172,10 +181,14 @@ public class KeylessTest {
   }
 
   @Test
-  @EnabledIfOidcExists(provider = OidcProviderType.ANY)
   @DisabledIfSkipStaging
   public void attest_staging() throws Exception {
-    var signer = KeylessSigner.builder().sigstoreStagingDefaults().enableRekorV2(true).build();
+    var signer =
+        KeylessSigner.builder()
+            .sigstoreStagingDefaults()
+            .forceCredentialProviders(CONFORMANCE_TOKEN_CLIENT)
+            .enableRekorV2(true)
+            .build();
     var result = signer.attest(payload);
 
     Assertions.assertNotNull(result.getDsseEnvelope().get());

--- a/sigstore-maven-plugin/src/test/java/dev/sigstore/plugin/test/MavenTestProject.java
+++ b/sigstore-maven-plugin/src/test/java/dev/sigstore/plugin/test/MavenTestProject.java
@@ -28,7 +28,7 @@ import org.apache.maven.it.util.ResourceExtractor;
 
 /**
  * Initialize a test project verifier. You should use this to inject the right local repository into
- * settings.xml and the proejct version into pom.xml. Works with the test Maven projects in the
+ * settings.xml and the project version into pom.xml. Works with the test Maven projects in the
  * {@code resources/maven/projects} directory.
  */
 public class MavenTestProject {

--- a/sigstore-testkit/src/main/java/dev/sigstore/testkit/oidc/ConformanceTestingToken.java
+++ b/sigstore-testkit/src/main/java/dev/sigstore/testkit/oidc/ConformanceTestingToken.java
@@ -29,33 +29,27 @@ import java.util.Map;
  * should never be used by actual signers and should only be available in tests. Use this with the
  * {@link TokenStringOidcClient}.
  */
-public class ConformanceTestingTokenProvider implements TokenStringOidcClient.TokenStringProvider {
+public class ConformanceTestingToken {
 
-  public static ConformanceTestingTokenProvider newProviderFromGithub() {
-    return new ConformanceTestingTokenProvider(
-        "https://raw.githubusercontent.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/refs/heads/current-token/oidc-token.txt");
+  public static TokenStringOidcClient.TokenStringProvider newProvider() {
+    return new TokenStringOidcClient.TokenStringProvider() {
+      @Override
+      public String getTokenString(Map<String, String> env) throws Exception {
+        return getToken();
+      }
+
+      @Override
+      public boolean isEnabled(Map<String, String> env) {
+        return true;
+      }
+    };
   }
 
-  public static ConformanceTestingTokenProvider newProviderFromGcp() {
-    return new ConformanceTestingTokenProvider(
-        "https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt");
-  }
-
-  private final String tokenUrl;
-
-  private ConformanceTestingTokenProvider(String tokenUrl) {
-    this.tokenUrl = tokenUrl;
-  }
-
-  @Override
-  public boolean isEnabled(Map<String, String> env) {
-    return true;
-  }
-
-  @Override
-  public String getTokenString(Map<String, String> env) throws Exception {
+  public static String getToken() throws Exception {
     HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
-    URI fileUri = new URI(tokenUrl);
+    URI fileUri =
+        new URI(
+            "https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt");
     HttpRequest request =
         HttpRequest.newBuilder()
             .uri(fileUri)


### PR DESCRIPTION
Use the Untrusted GCP Beacon token provider dynamically in all tests and workflow examples, mostly avoiding dependency on ambient OIDC configuration in local development.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
