### PR TITLE
Spotless update

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     implementation(project(":basics"))
     implementation(project(":build-parameters"))
-    implementation("com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:8.1.0")
+    implementation("com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:8.6.0")
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:3.0.2")
     implementation("de.thetaphi.forbiddenapis:de.thetaphi.forbiddenapis.gradle.plugin:3.10")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     id("com.gradleup.nmcp.aggregation") version "1.4.0"
     // The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
     `embedded-kotlin` apply false
+    // The Spotless plugin uses a shared build service. Load it at the root project level to avoid classloader collision in subprojects.
+    id("com.diffplug.spotless") version "8.6.0" apply false
 }
 
 val calculatedVersion = property("version") as String + (if (hasProperty("release")) "" else "-SNAPSHOT")


### PR DESCRIPTION
Not sure if this is the most elegant solution, but seems to be what is required for this problem. We might be able to share version information via a toml version catalog. But hopefully updates happen as a group