### PR TITLE
Support Isolated Projects: BuildServicesRegistry.getRegistrations.get…

### DIFF
--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
@@ -16,14 +16,15 @@
  */
 import dev.sigstore.sign.SigstoreSignExtension
 import dev.sigstore.sign.services.SigstoreSigningService
+import dev.sigstore.sign.tasks.SigstoreSignFilesTask
 
 // https://github.com/gradle/gradle/pull/16627
 inline fun <reified T: Named> AttributeContainer.attribute(attr: Attribute<T>, value: String) =
     attribute(attr, objects.named<T>(value))
 
-val sigstoreSign = extensions.create("sigstoreSign", SigstoreSignExtension::class, project)
+val sigstoreSign = extensions.create("sigstoreSign", SigstoreSignExtension::class)
 
-gradle.sharedServices.registerIfAbsent(SigstoreSigningService.SERVICE_NAME, SigstoreSigningService::class) {
+val service = gradle.sharedServices.registerIfAbsent(SigstoreSigningService.SERVICE_NAME, SigstoreSigningService::class) {
     parameters {
         // Prevents concurrent execution of tasks that use the service, so we ensure there's only one signing task active at a time
         maxParallelUsages.set(1)
@@ -41,7 +42,7 @@ val sigstoreClient = configurations.create("sigstoreClient") {
     }
 }
 
-val sigstoreClientClasspath = configurations.create("sigstoreClientClasspath") {
+val sigstoreClientClasspathConf = configurations.register("sigstoreClientClasspath") {
     description = "Resolves Sigstore dependencies"
     isCanBeResolved = true
     isCanBeConsumed = false
@@ -53,4 +54,16 @@ val sigstoreClientClasspath = configurations.create("sigstoreClientClasspath") {
         attribute(Bundling.BUNDLING_ATTRIBUTE, Bundling.EXTERNAL)
         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInt())
     }
+}
+
+private val PROPERTY_SET_PROVIDER = Property::class.java.getMethod("set", Provider::class.java)
+
+tasks.withType<SigstoreSignFilesTask>().configureEach {
+    // Use reflection to resolve set(Provider) vs set(Object) ambiguity
+    // Needed, because Type is `Any` to workaround https://github.com/gradle/gradle/issues/17559
+    PROPERTY_SET_PROVIDER.invoke(signingService, service)
+    // See https://docs.gradle.org/current/userguide/build_services.html
+    usesService(service)
+
+    sigstoreClientClasspath.from(sigstoreClientClasspathConf)
 }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev.sigstore.sign-base.gradle.kts
@@ -56,13 +56,9 @@ val sigstoreClientClasspathConf = configurations.register("sigstoreClientClasspa
     }
 }
 
-private val PROPERTY_SET_PROVIDER = Property::class.java.getMethod("set", Provider::class.java)
-
 tasks.withType<SigstoreSignFilesTask>().configureEach {
-    // Use reflection to resolve set(Provider) vs set(Object) ambiguity
-    // Needed, because Type is `Any` to workaround https://github.com/gradle/gradle/issues/17559
-    PROPERTY_SET_PROVIDER.invoke(signingService, service)
     // See https://docs.gradle.org/current/userguide/build_services.html
+    signingService.set(service)
     usesService(service)
 
     sigstoreClientClasspath.from(sigstoreClientClasspathConf)

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/SigstoreSignExtension.kt
@@ -17,29 +17,25 @@
 package dev.sigstore.sign
 
 import dev.sigstore.sign.tasks.SigstoreSignFilesTask
-import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.publish.Publication
 import org.gradle.api.publish.PublicationArtifact
 import org.gradle.api.publish.internal.PublicationInternal
-import org.gradle.api.publish.maven.MavenArtifact
 import org.gradle.api.publish.maven.internal.artifact.AbstractMavenArtifact
 import org.gradle.api.publish.maven.internal.artifact.DerivedMavenArtifact
-import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.the
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.Sign
 import org.gradle.util.GradleVersion
+import javax.inject.Inject
 import kotlin.collections.set
 
-abstract class SigstoreSignExtension(private val project: Project) {
+abstract class SigstoreSignExtension @Inject constructor (private val project: Project) {
     private val Publication.signingTaskName: String
         get() = "sigstoreSign${name.titlecase()}Publication"
 

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/services/SigstoreSigningService.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/services/SigstoreSigningService.kt
@@ -28,6 +28,5 @@ abstract class SigstoreSigningService: BuildService<SigstoreSigningService.Param
         const val SERVICE_NAME = "sigstoreJavaSigningService"
     }
 
-    interface Params: BuildServiceParameters {
-    }
+    interface Params: BuildServiceParameters
 }

--- a/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/tasks/SigstoreSignFilesTask.kt
+++ b/sigstore-gradle/sigstore-gradle-sign-base-plugin/src/main/kotlin/dev/sigstore/sign/tasks/SigstoreSignFilesTask.kt
@@ -16,16 +16,13 @@
  */
 package dev.sigstore.sign.tasks
 
-import dev.sigstore.sign.SigstoreSignExtension
 import dev.sigstore.sign.SigstoreSignature
-import dev.sigstore.sign.services.SigstoreSigningService
 import dev.sigstore.sign.work.SignWorkAction
 import org.gradle.api.Buildable
 import org.gradle.api.DefaultTask
 import org.gradle.api.JavaVersion
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.*
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -34,7 +31,6 @@ import org.gradle.api.tasks.*
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.findByType
-import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.the
 import org.gradle.work.DisableCachingByDefault
 import org.gradle.workers.WorkerExecutor
@@ -43,22 +39,6 @@ import javax.inject.Inject
 
 @DisableCachingByDefault(because = "Sigstore signatures are true-timestamp dependent, so we should not cache signatures")
 abstract class SigstoreSignFilesTask : DefaultTask() {
-    companion object {
-        private val PROPERTY_SET_PROVIDER = Property::class.java.getMethod("set", Provider::class.java)
-    }
-
-    init {
-        @Suppress("UNCHECKED_CAST")
-        val service: Provider<SigstoreSigningService> =
-            project.gradle.sharedServices.registrations[SigstoreSigningService.SERVICE_NAME].service as Provider<SigstoreSigningService>
-
-        // Use reflection to resolve set(Provider) vs set(Object) ambiguity
-        @Suppress("LeakingThis")
-        PROPERTY_SET_PROVIDER.invoke(signingService, service)
-        // See https://docs.gradle.org/current/userguide/build_services.html
-        @Suppress("LeakingThis")
-        usesService(service)
-    }
 
     /**
      * Signing service is there so none of the signing tasks execute concurrently.
@@ -67,20 +47,13 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
      * Type is `Any` to workaround https://github.com/gradle/gradle/issues/17559
      */
     @get:Internal
-    protected abstract val signingService: Property<Any>
+    internal abstract val signingService: Property<Any>
 
-    @Nested
-    val signatures: NamedDomainObjectContainer<SigstoreSignature> =
-        objects.domainObjectContainer(SigstoreSignature::class.java) {
-            objects.newInstance(
-                SigstoreSignature::class.java,
-                it,
-            )
-        }
+    @get:Nested
+    abstract val signatures: NamedDomainObjectContainer<SigstoreSignature>
 
     @get:Classpath
-    @get:InputFiles
-    protected abstract val sigstoreClientClasspath: ConfigurableFileCollection
+    abstract val sigstoreClientClasspath: ConfigurableFileCollection
 
     @get:Internal
     abstract val signatureDirectory: DirectoryProperty
@@ -96,9 +69,6 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
     protected abstract val providers: ProviderFactory
 
     @get:Inject
-    protected abstract val objects: ObjectFactory
-
-    @get:Inject
     protected abstract val layout: ProjectLayout
 
     init {
@@ -109,7 +79,6 @@ abstract class SigstoreSignFilesTask : DefaultTask() {
         outputs.cacheIf("Sigstore signatures are true-timestamp dependent, so we should not cache signatures") {
             false
         }
-        sigstoreClientClasspath.from(project.configurations["sigstoreClientClasspath"])
         signatureDirectory.convention(
             layout.buildDirectory.dir("sigstore/$name")
         )

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
@@ -232,12 +232,21 @@ open class BaseGradleTest {
         require(gradle.configurationCache == ConfigurationCache.ON) {
             "Project isolation requires Configuration Cache."
         }
-        projectDir.resolve("gradle.properties").appendText(
-            """
+        if (gradle.version >= GradleVersion.version("9.7")) {
+            projectDir.resolve("gradle.properties").appendText(
+                """
 
-            org.gradle.unsafe.isolated-projects=true
-            """.trimIndent()
-        )
+                org.gradle.isolated-projects=true
+                """.trimIndent()
+            )
+        } else {
+            projectDir.resolve("gradle.properties").appendText(
+                """
+
+                org.gradle.unsafe.isolated-projects=true
+                """.trimIndent()
+            )
+        }
     }
 
     protected fun assertSoftly(body: SoftAssertions.() -> Unit) =

--- a/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
+++ b/sigstore-testkit/src/main/kotlin/dev/sigstore/testkit/BaseGradleTest.kt
@@ -71,6 +71,7 @@ open class BaseGradleTest {
             "8.14.3",
             "9.1.0",
             "9.2.0",
+            "9.7.1",
         ).map { GradleVersion.version(it) }
             .filter {
                 // See https://docs.gradle.org/current/userguide/compatibility.html


### PR DESCRIPTION
…ByName is not allowed (anymore)

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes #1245

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Add support for Isolated Projects when using Gradle 9.7

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
