### PR TITLE
Add automatic module name

### DIFF
--- a/sigstore-java/build.gradle.kts
+++ b/sigstore-java/build.gradle.kts
@@ -10,6 +10,13 @@ plugins {
 
 description = "A Java client for signing and verifying using Sigstore"
 
+tasks.jar {
+    manifest {
+        // Name of the automatic module for JPMS consumers. It must never change once released.
+        attributes["Automatic-Module-Name"] = "dev.sigstore"
+    }
+}
+
 dependencies {
     compileOnly("org.immutables:gson:2.12.2")
     compileOnly("org.immutables:value-annotations:2.12.2")


### PR DESCRIPTION
Closes #1268.

Adds `Automatic-Module-Name: dev.sigstore`. As in the issue, only sigstore-java gets one.

The other two commits are what make that name usable, both are about compatibility on the module path.

sigstore-java compiled its own copies of `google/api/{annotations,field_behavior,http}.proto` and shipped the resulting `com.google.api` classes in the jar. Those are the same class names that `proto-google-common-protos` publishes, and that artifact is already on the runtime class path via grpc-protobuf. So the copies never really solved anything: the fully qualified names are identical either way, and which one wins comes down to class path order. On the module path it is not silent any more:

```
java.lang.module.ResolutionException: Module proto.google.common.protos contains
package com.google.api, module dev.sigstore exports package com.google.api to
proto.google.common.protos
```

The README kept the copies because `proto-google-common-protos` had gone stale. It is at 2.74.0 now, and its versions of those three files are identical to ours apart from a `cc_enable_arenas` option that only affects C++. So I dropped them and declared the dependency explicitly, since `BundleVerifier` links against `com.google.api` directly and only got it transitively before.

Same story for the DSSE envelope. `envelope.proto` sets `go_package` and `ruby_package` but no `java_package`, so protoc put `Envelope` and `Signature` in `io.intoto` and shipped them. protobuf-specs has published protos only since 0.3.2, so these are generated here regardless and the Java package is ours to pick. I set it to `dev.sigstore.proto.dsse`, matching what the sibling protos already do.

That last one is a breaking change for Java callers, `Bundle.getDsseEnvelope()` and friends change type. Only the Java package moves though. The proto package stays `io.intoto`, so the descriptor is still `io.intoto.Envelope`, and the wire and JSON encodings are unchanged. Existing bundles stay valid.

Happy to split the envelope commit out if you would rather take that separately.
